### PR TITLE
Label gcp provider image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,5 @@ RUN unset VERSION \
 FROM registry.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/machine-api-provider-gcp/bin/machine-controller-manager /
 COPY --from=builder /go/src/github.com/openshift/machine-api-provider-gcp/bin/termination-handler /
+
+LABEL io.openshift.release.operator true


### PR DESCRIPTION
We need to set io.openshift.release.operator true label for all images that go in release