### PR TITLE
Updating ose-machine-api-provider-gcp images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.12
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-api-provider-gcp
 COPY . .
 # VERSION env gets set in the openshift/release image and refers to the golang version, which interfers with our own

--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -289,7 +289,7 @@ func TestCreate(t *testing.T) {
 			},
 			providerSpec: &machinev1.GCPMachineProviderSpec{
 				Metadata: []*machinev1.GCPMetadata{
-					&machinev1.GCPMetadata{
+					{
 						Key:   windowsScriptMetadataKey,
 						Value: pointer.String("the proper script value"),
 					},

--- a/pkg/cloud/gcp/actuators/util/gcp_credentials.go
+++ b/pkg/cloud/gcp/actuators/util/gcp_credentials.go
@@ -35,14 +35,14 @@ const (
 // This expects the https://github.com/openshift/cloud-credential-operator to make a secret
 // with a serviceAccount JSON Key content available. E.g:
 //
-// apiVersion: v1
-// kind: Secret
-// metadata:
-//  name: gcp-sa
-//  namespace: openshift-machine-api
-// type: Opaque
-// data:
-//  serviceAccountJSON: base64 encoded content of the file
+//	apiVersion: v1
+//	kind: Secret
+//	metadata:
+//	 name: gcp-sa
+//	 namespace: openshift-machine-api
+//	type: Opaque
+//	data:
+//	 serviceAccountJSON: base64 encoded content of the file
 func GetCredentialsSecret(coreClient controllerclient.Client, namespace string, spec machinev1.GCPMachineProviderSpec) (string, error) {
 	if spec.CredentialsSecret == nil {
 		return "", nil


### PR DESCRIPTION
Cherry-picked from #18 

Apply go fmt in follow up commit