### PR TITLE
OCPBUGS-3904: Register unknown instance groups

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -660,8 +660,8 @@ func TestRegisterInstanceToControlPlaneInstanceGroup(t *testing.T) {
 	addGroupSuccessfully := okScope
 	addGroupSuccessfully.projectID = computeservice.AddGroupSuccessfully
 
-	errRegisteringNewInstanceGroup := okScope
-	errRegisteringNewInstanceGroup.projectID = computeservice.ErrRegisteringNewInstanceGroup
+	errFailGroupGet := okScope
+	errFailGroupGet.projectID = computeservice.ErrFailGroupGet
 
 	groupNotInBackendService := okScope
 	groupNotInBackendService.projectID = computeservice.PatchBackendService
@@ -698,17 +698,18 @@ func TestRegisterInstanceToControlPlaneInstanceGroup(t *testing.T) {
 			scope:       &addGroupSuccessfully,
 		},
 		{
-			// Error registering new instanceGroup
+			// Error getting an instance group
 			expectedErr: true,
-			errString:   "failed to register new instanceGroup",
-			scope:       &errRegisteringNewInstanceGroup,
+			errString:   "instanceGroupGet request failed",
+			scope:       &errFailGroupGet,
 		},
 		{
 			// Error adding instanceGroup to backend service
 			expectedErr: true,
-			errString: "failed to update the backend service with new instance group " +
-				"CLUSTERID-master-zone1: backendServiceGet request failed: failed to get " +
-				"the regional backend service",
+			errString: "failed to ensure that instance group " +
+				"CLUSTERID-master-zone1 is a proper instance group: " +
+				"failed to retrieve the backend service: backendServiceGet " +
+				"request failed: failed to get the regional backend service",
 			scope: &errNewGroupToBackendService,
 		},
 		{

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -31,6 +31,7 @@ type GCPComputeService interface {
 	InstanceGroupsListInstances(project string, zone string, instanceGroup string, request *compute.InstanceGroupsListInstancesRequest) (*compute.InstanceGroupsListInstances, error)
 	InstanceGroupsAddInstances(project string, zone string, instance string, instanceGroup string) (*compute.Operation, error)
 	InstanceGroupsRemoveInstances(project string, zone string, instance string, instanceGroup string) (*compute.Operation, error)
+	InstanceGroupInsert(project string, zone string, instanceGroup *compute.InstanceGroup) (*compute.Operation, error)
 }
 
 type computeService struct {
@@ -170,4 +171,8 @@ func (c *computeService) InstanceGroupsRemoveInstances(project string, zone stri
 
 func (c *computeService) InstanceGroupsListInstances(project string, zone string, instanceGroup string, request *compute.InstanceGroupsListInstancesRequest) (*compute.InstanceGroupsListInstances, error) {
 	return c.service.InstanceGroups.ListInstances(project, zone, instanceGroup, request).Do()
+}
+
+func (c *computeService) InstanceGroupInsert(project string, zone string, instanceGroup *compute.InstanceGroup) (*compute.Operation, error) {
+	return c.service.InstanceGroups.Insert(project, zone, instanceGroup).Do()
 }

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -32,6 +32,9 @@ type GCPComputeService interface {
 	InstanceGroupsAddInstances(project string, zone string, instance string, instanceGroup string) (*compute.Operation, error)
 	InstanceGroupsRemoveInstances(project string, zone string, instance string, instanceGroup string) (*compute.Operation, error)
 	InstanceGroupInsert(project string, zone string, instanceGroup *compute.InstanceGroup) (*compute.Operation, error)
+	InstanceGroupGet(project string, zone string, instanceGroupName string) (*compute.InstanceGroup, error)
+	AddInstanceGroupToBackendService(project string, region string, backendServiceName string, backendService *compute.BackendService) (*compute.Operation, error)
+	BackendServiceGet(project string, region string, backendServiceName string) (*compute.BackendService, error)
 }
 
 type computeService struct {
@@ -175,4 +178,16 @@ func (c *computeService) InstanceGroupsListInstances(project string, zone string
 
 func (c *computeService) InstanceGroupInsert(project string, zone string, instanceGroup *compute.InstanceGroup) (*compute.Operation, error) {
 	return c.service.InstanceGroups.Insert(project, zone, instanceGroup).Do()
+}
+
+func (c *computeService) InstanceGroupGet(project string, zone string, instanceGroupName string) (*compute.InstanceGroup, error) {
+	return c.service.InstanceGroups.Get(project, zone, instanceGroupName).Do()
+}
+
+func (c *computeService) AddInstanceGroupToBackendService(project string, region string, backendServiceName string, backendService *compute.BackendService) (*compute.Operation, error) {
+	return c.service.RegionBackendServices.Update(project, region, backendServiceName, backendService).Do()
+}
+
+func (c *computeService) BackendServiceGet(project string, region string, backendServiceName string) (*compute.BackendService, error) {
+	return c.service.RegionBackendServices.Get(project, region, backendServiceName).Do()
 }

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -19,6 +19,8 @@ const (
 	ErrRegisteringNewInstanceGroup = "errRegisteringNewInstanceGroup"
 	ErrPatchingBackendService      = "errPatchingBackendService"
 	ErrGettingBackendService       = "errGettingBackendService"
+	ErrFailGroupGet                = "errFailGroupGet"
+	ErrGroupNotFound               = "errGroupNotFound"
 	PatchBackendService            = "patchBackendService"
 	AddGroupSuccessfully           = "addGroupSuccessfully"
 )
@@ -215,14 +217,16 @@ func (c *GCPComputeServiceMock) InstanceGroupInsert(project string, zone string,
 }
 
 func (c *GCPComputeServiceMock) InstanceGroupGet(project string, zone string, instanceGroupName string) (*compute.InstanceGroup, error) {
-	if project == ErrRegisteringNewInstanceGroup {
-		return nil, errors.New("failed to get the instanceGroup")
+	if project == ErrFailGroupGet {
+		return nil, errors.New("instanceGroupGet request failed")
 	}
-	return &compute.InstanceGroup{}, nil
+	if project == ErrGroupNotFound {
+		return nil, errors.New("instanceGroupGet request failed")
+	}
+	return nil, nil
 }
 
 func (c *GCPComputeServiceMock) AddInstanceGroupToBackendService(project string, region string, backendServiceName string, backendService *compute.BackendService) (*compute.Operation, error) {
-	fmt.Printf("I am here and this is the project %s\n\n", project)
 	if project == ErrPatchingBackendService {
 		return nil, errors.New("failed to add new instanceGroup to backend service")
 	}

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -9,12 +9,13 @@ import (
 )
 
 const (
-	NoMachinesInPool         = "NoMachinesInPool"
-	WithMachineInPool        = "WithMachineInPool"
-	GroupDoesNotExist        = "groupDoesNotExist"
-	EmptyInstanceList        = "emptyInstanceList"
-	ErrUnregisteringInstance = "errUnregisteringInstance"
-	ErrRegisteringInstance   = "errRegisteringInstance"
+	NoMachinesInPool               = "NoMachinesInPool"
+	WithMachineInPool              = "WithMachineInPool"
+	GroupDoesNotExist              = "groupDoesNotExist"
+	EmptyInstanceList              = "emptyInstanceList"
+	ErrUnregisteringInstance       = "errUnregisteringInstance"
+	ErrRegisteringInstance         = "errRegisteringInstance"
+	ErrRegisteringNewInstanceGroup = "errRegisteringNewInstanceGroup"
 )
 
 type GCPComputeServiceMock struct {
@@ -193,4 +194,17 @@ func (c *GCPComputeServiceMock) InstanceGroupsRemoveInstances(project string, zo
 	return &compute.Operation{
 		Status: "DONE",
 	}, nil
+}
+
+func (c *GCPComputeServiceMock) InstanceGroupInsert(project string, zone string, instanceGroup *compute.InstanceGroup) (*compute.Operation, error) {
+	if project == GroupDoesNotExist {
+		return &compute.Operation{
+			Status: "DONE",
+		}, nil
+
+	}
+	if project == ErrRegisteringNewInstanceGroup {
+		return nil, errors.New("failed to register new instanceGroup")
+	}
+	return nil, nil
 }

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -16,6 +16,8 @@ const (
 	ErrUnregisteringInstance       = "errUnregisteringInstance"
 	ErrRegisteringInstance         = "errRegisteringInstance"
 	ErrRegisteringNewInstanceGroup = "errRegisteringNewInstanceGroup"
+	ErrPatchingBackendService      = "errPatchingBackendService"
+	ErrGettingBackendService       = "errGettingBackendService"
 )
 
 type GCPComputeServiceMock struct {
@@ -207,4 +209,24 @@ func (c *GCPComputeServiceMock) InstanceGroupInsert(project string, zone string,
 		return nil, errors.New("failed to register new instanceGroup")
 	}
 	return nil, nil
+}
+
+func (c *GCPComputeServiceMock) InstanceGroupGet(project string, zone string, instanceGroupName string) (*compute.InstanceGroup, error) {
+	return &compute.InstanceGroup{}, nil
+}
+
+func (c *GCPComputeServiceMock) AddInstanceGroupToBackendService(project string, region string, backendServiceName string, backendService *compute.BackendService) (*compute.Operation, error) {
+	if project == ErrPatchingBackendService {
+		return nil, errors.New("failed to add new instanceGroup to backend service")
+	}
+	return &compute.Operation{
+		Status: "DONE",
+	}, nil
+}
+
+func (c *GCPComputeServiceMock) BackendServiceGet(project string, region string, backendServiceName string) (*compute.BackendService, error) {
+	if project == ErrGettingBackendService {
+		return nil, errors.New("failed to get the regional backend service")
+	}
+	return &compute.BackendService{}, nil
 }


### PR DESCRIPTION
This PR solves a bug, where machines were stuck in add/delete phase when removing a failure domain from CPMS.
Whenever we encounter an instance group that is unknown to us, we register it.

Edit: Have to add that new instance group to load balancer.