### PR TITLE
OCPBUGS-860: Set sync period for Machine controller

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -84,12 +84,17 @@ func main() {
 
 	cfg := config.GetConfigOrDie()
 
+	// Override the default 10 hour sync period so that we pick up external changes
+	// to the VMs within a reasonable time frame.
+	syncPeriod := 10 * time.Minute
+
 	opts := manager.Options{
 		LeaderElection:          *leaderElect,
 		LeaderElectionNamespace: *leaderElectResourceNamespace,
 		LeaderElectionID:        "cluster-api-provider-gcp-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
 		HealthProbeBindAddress:  *healthAddr,
+		SyncPeriod:              &syncPeriod,
 		MetricsBindAddress:      *metricsAddress,
 		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
 		RetryPeriod:   &retryPeriod,


### PR DESCRIPTION
On other providers we set the sync period to 10 minutes down from the default of 10 hours. This means we pick up changes within the cloud provider in a reasonable time frame.

For example, if a user adds an external IP address manually, this should be picked up so that CSRs for the serving certificates are approved in a timely manner, this isn't working well with the default sync period.

10 minutes is used in other providers such as AWS and Azure.