### PR TITLE
[release-4.12] OCPBUGS-4504: refactor restartPolicyToBool function

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -62,9 +64,21 @@ func containsString(sli []string, str string) bool {
 	return false
 }
 
-func restartPolicyToBool(policy machinev1.GCPRestartPolicyType) *bool {
-	restart := policy == machinev1.RestartPolicyAlways
-	return &restart
+func restartPolicyToBool(policy machinev1.GCPRestartPolicyType, preemptible bool) (*bool, error) {
+	// for more information about how the restart policy works, see the GCP docs at
+	// https://cloud.google.com/compute/docs/instances/setting-vm-host-options#settingoptions
+	if len(policy) == 0 {
+		return nil, nil
+	} else if policy == machinev1.RestartPolicyAlways {
+		if preemptible {
+			return nil, errors.New("preemptible instances cannot be automatically restarted")
+		}
+		return pointer.Bool(true), nil
+	} else if policy == machinev1.RestartPolicyNever {
+		return pointer.Bool(false), nil
+	}
+
+	return nil, fmt.Errorf("unrecognized restart policy: %s", policy)
 }
 
 // machineTypeAcceleratorCount represents nvidia-tesla-A100 GPUs which are only compatible with A2 machine family
@@ -157,9 +171,14 @@ func (r *Reconciler) create() error {
 		},
 		Scheduling: &compute.Scheduling{
 			Preemptible:       r.providerSpec.Preemptible,
-			AutomaticRestart:  restartPolicyToBool(r.providerSpec.RestartPolicy),
 			OnHostMaintenance: string(r.providerSpec.OnHostMaintenance),
 		},
+	}
+
+	if automaticRestart, err := restartPolicyToBool(r.providerSpec.RestartPolicy, r.providerSpec.Preemptible); err != nil {
+		return machinecontroller.InvalidMachineConfiguration("failed to determine restart policy: %v", err)
+	} else {
+		instance.Scheduling.AutomaticRestart = automaticRestart
 	}
 
 	var guestAccelerators = []*compute.AcceleratorConfig{}


### PR DESCRIPTION
this is a cherry-pick of #21 

to be more thorough about checking for empty string and preemptible instances. previously this function only checked if the value was equal to "Always". but, this misses the default omission case where we should be defaulting to always restart but weren't. additionally, errors have been added when the policy is not recognized or the user attempts to set an always restart policy for a preemptible instance.