### PR TITLE
[release-4.11] OCPBUGS-4579: refactor restartPolicyToBool function

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -60,9 +62,21 @@ func containsString(sli []string, str string) bool {
 	return false
 }
 
-func restartPolicyToBool(policy machinev1.GCPRestartPolicyType) *bool {
-	restart := policy == machinev1.RestartPolicyAlways
-	return &restart
+func restartPolicyToBool(policy machinev1.GCPRestartPolicyType, preemptible bool) (*bool, error) {
+	// for more information about how the restart policy works, see the GCP docs at
+	// https://cloud.google.com/compute/docs/instances/setting-vm-host-options#settingoptions
+	if len(policy) == 0 {
+		return nil, nil
+	} else if policy == machinev1.RestartPolicyAlways {
+		if preemptible {
+			return nil, errors.New("preemptible instances cannot be automatically restarted")
+		}
+		return pointer.Bool(true), nil
+	} else if policy == machinev1.RestartPolicyNever {
+		return pointer.Bool(false), nil
+	}
+
+	return nil, fmt.Errorf("unrecognized restart policy: %s", policy)
 }
 
 // machineTypeAcceleratorCount represents nvidia-tesla-A100 GPUs which are only compatible with A2 machine family
@@ -155,9 +169,14 @@ func (r *Reconciler) create() error {
 		},
 		Scheduling: &compute.Scheduling{
 			Preemptible:       r.providerSpec.Preemptible,
-			AutomaticRestart:  restartPolicyToBool(r.providerSpec.RestartPolicy),
 			OnHostMaintenance: string(r.providerSpec.OnHostMaintenance),
 		},
+	}
+
+	if automaticRestart, err := restartPolicyToBool(r.providerSpec.RestartPolicy, r.providerSpec.Preemptible); err != nil {
+		return machinecontroller.InvalidMachineConfiguration("failed to determine restart policy: %v", err)
+	} else {
+		instance.Scheduling.AutomaticRestart = automaticRestart
 	}
 
 	var guestAccelerators = []*compute.AcceleratorConfig{}

--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/openshift/api/machine/v1beta1"
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	computeservice "github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/services/compute"
@@ -13,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -245,6 +247,51 @@ func TestCreate(t *testing.T) {
 					t.Errorf("Expected KmsKeyServiceAccount: %q, Got KmsKeyServiceAccount: %q", expectedKmsKeyServiceAccount, diskEncryption.KmsKeyServiceAccount)
 				}
 			},
+		},
+		{
+			name: "Always restart policy with a preemptible instance produces an error",
+			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Preemptible:   true,
+				RestartPolicy: v1beta1.RestartPolicyAlways,
+			},
+			expectedError: errors.New("failed to determine restart policy: preemptible instances cannot be automatically restarted"),
+		},
+		{
+			name: "Always restart policy with a non-preemptible instance does not produce an error",
+			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Preemptible:   false,
+				RestartPolicy: v1beta1.RestartPolicyAlways,
+			},
+		},
+		{
+			name: "Never restart policy with a preemptible instance does not produce an error",
+			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Preemptible:   true,
+				RestartPolicy: v1beta1.RestartPolicyNever,
+			},
+		},
+		{
+			name: "Never restart policy with a non-preemptible instance does not produce an error",
+			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Preemptible:   false,
+				RestartPolicy: v1beta1.RestartPolicyNever,
+			},
+		},
+		{
+			name: "Unknown restart policy with a preemptible instance produces an error",
+			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Preemptible:   true,
+				RestartPolicy: "SometimesMaybe",
+			},
+			expectedError: errors.New("failed to determine restart policy: unrecognized restart policy: SometimesMaybe"),
+		},
+		{
+			name: "Unknown restart policy with a non-preemptible instance produces an error",
+			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Preemptible:   false,
+				RestartPolicy: "SometimesMaybe",
+			},
+			expectedError: errors.New("failed to determine restart policy: unrecognized restart policy: SometimesMaybe"),
 		},
 	}
 
@@ -674,5 +721,97 @@ func TestSetMachineCloudProviderSpecifics(t *testing.T) {
 
 	if _, ok := r.machine.Spec.Labels[machinecontroller.MachineInterruptibleInstanceLabelName]; !ok {
 		t.Error("Missing spot instance label in machine spec")
+	}
+}
+
+func TestRestartPolicyToBool(t *testing.T) {
+	cases := []struct {
+		name           string
+		policy         v1beta1.GCPRestartPolicyType
+		preemptible    bool
+		expectedReturn *bool
+		expectedError  error
+	}{
+		{
+			name:           "Empty policy with non-preemptible returns nil and no error",
+			policy:         "",
+			preemptible:    false,
+			expectedReturn: nil,
+			expectedError:  nil,
+		},
+		{
+			name:           "Empty policy with preemptible returns nil and no error",
+			policy:         "",
+			preemptible:    true,
+			expectedReturn: nil,
+			expectedError:  nil,
+		},
+		{
+			name:           "Always policy with non-preemptible returns true and no error",
+			policy:         v1beta1.RestartPolicyAlways,
+			preemptible:    false,
+			expectedReturn: pointer.Bool(true),
+			expectedError:  nil,
+		},
+		{
+			name:           "Always policy with preemptible returns nil and an error",
+			policy:         v1beta1.RestartPolicyAlways,
+			preemptible:    true,
+			expectedReturn: nil,
+			expectedError:  errors.New("preemptible instances cannot be automatically restarted"),
+		},
+		{
+			name:           "Never policy with non-preemptible returns false and no error",
+			policy:         v1beta1.RestartPolicyNever,
+			preemptible:    false,
+			expectedReturn: pointer.Bool(false),
+			expectedError:  nil,
+		},
+		{
+			name:           "Never policy with preemptible returns false and no error",
+			policy:         v1beta1.RestartPolicyNever,
+			preemptible:    true,
+			expectedReturn: pointer.Bool(false),
+			expectedError:  nil,
+		},
+		{
+			name:           "Unknown policy with non-preemptible returns nil and an error",
+			policy:         "SometimesMaybe",
+			preemptible:    false,
+			expectedReturn: nil,
+			expectedError:  errors.New("unrecognized restart policy: SometimesMaybe"),
+		},
+		{
+			name:           "Unknown policy with preemptible returns nil and an error",
+			policy:         "SometimesMaybe",
+			preemptible:    true,
+			expectedReturn: nil,
+			expectedError:  errors.New("unrecognized restart policy: SometimesMaybe"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			observedReturn, observedError := restartPolicyToBool(tc.policy, tc.preemptible)
+
+			if tc.expectedReturn == nil && observedReturn != nil {
+				t.Errorf("Expected nil return value, got: %v", *observedReturn)
+			} else if observedReturn != nil && *tc.expectedReturn != *observedReturn {
+				t.Errorf("Expected return value: %v, got: %v", *tc.expectedReturn, *observedReturn)
+			}
+
+			if tc.expectedError != nil {
+				if observedError == nil {
+					t.Error("restartPolicyToBool was expected to return error")
+				}
+				if observedError.Error() != tc.expectedError.Error() {
+					t.Errorf("Expected: %v, got %v", tc.expectedError, observedError)
+				}
+			} else {
+				if observedError != nil {
+					t.Errorf("restartPolicyToBool was not expected to return error: %v", observedError)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
this is a cherry-pick of #21 

to be more thorough about checking for empty string and preemptible instances. previously this function only checked if the value was equal to "Always". but, this misses the default omission case where we should be defaulting to always restart but weren't. additionally, errors have been added when the policy is not recognized or the user attempts to set an always restart policy for a preemptible instance.

fixes OCPBUGS-4579