### PR TITLE
OCPBUGS-7366: New machine stuck in provisioning on VPC

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -667,20 +667,16 @@ func (r *Reconciler) ensureInstanceGroup(instanceGroupName string) error {
 // In a case of VPC, we have to look whether the expect name of the network and subnet resource
 // matches the one, that is actually up in the cluster.
 func (r *Reconciler) ensureCorrectNetworkAndSubnetName() (string, string, error) {
-	foundNetworkInterface := false
 	actualNetworkName := fmt.Sprintf("%s-network", r.machine.Labels[machinev1.MachineClusterIDLabel])
 	actualSubnetworkName := fmt.Sprintf("%s-%s-subnet", r.machine.Labels[machinev1.MachineClusterIDLabel], r.machineScope.machine.ObjectMeta.Labels[openshiftMachineRoleLabel])
 
 	for _, network := range r.providerSpec.NetworkInterfaces {
 		if network.Network == actualNetworkName && network.Subnetwork == actualSubnetworkName {
-			foundNetworkInterface = true
-			break
+			return actualNetworkName, actualSubnetworkName, nil
 		}
 	}
-	if !foundNetworkInterface {
-		actualNetworkName = r.providerSpec.NetworkInterfaces[0].Network
-		actualSubnetworkName = r.providerSpec.NetworkInterfaces[0].Subnetwork
-	}
+	actualNetworkName = r.providerSpec.NetworkInterfaces[0].Network
+	actualSubnetworkName = r.providerSpec.NetworkInterfaces[0].Subnetwork
 
 	return actualNetworkName, actualSubnetworkName, nil
 }

--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -670,6 +670,7 @@ func (r *Reconciler) ensureCorrectNetworkAndSubnetName() (string, string, error)
 	foundNetworkInterface := false
 	actualNetworkName := fmt.Sprintf("%s-network", r.machine.Labels[machinev1.MachineClusterIDLabel])
 	actualSubnetworkName := fmt.Sprintf("%s-%s-subnet", r.machine.Labels[machinev1.MachineClusterIDLabel], r.machineScope.machine.ObjectMeta.Labels[openshiftMachineRoleLabel])
+
 	for _, network := range r.providerSpec.NetworkInterfaces {
 		if network.Network == actualNetworkName && network.Subnetwork == actualSubnetworkName {
 			foundNetworkInterface = true

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -247,8 +247,3 @@ func (c *GCPComputeServiceMock) BackendServiceGet(project string, region string,
 		},
 	}, nil
 }
-
-func (c *GCPComputeServiceMock) NetworksList(project string) (*compute.NetworkList, error) {
-	// TODO: Work this out for unit test for VPC network
-	return nil, nil
-}

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -247,3 +247,8 @@ func (c *GCPComputeServiceMock) BackendServiceGet(project string, region string,
 		},
 	}, nil
 }
+
+func (c *GCPComputeServiceMock) NetworksList(project string) (*compute.NetworkList, error) {
+	// TODO: Work this out for unit test for VPC network
+	return nil, nil
+}


### PR DESCRIPTION
New machine is stuck in `Provisioning` when we delete one of the zones from CPMS on GCP :  "The resource `<path-to-network-resource>` not found".

- [x] Propose a solution to the bug
- [x] Create unit test(s) covering this issue
- [x] Test this issue on running GCP cluster with custom VPC network

Edit: This got tested pre-merged by QE.