### PR TITLE
MIXEDARCH-258: Set the capacity annotation for arch-aware autoscale from zero

### DIFF
--- a/pkg/cloud/gcp/actuators/machineset/controller_test.go
+++ b/pkg/cloud/gcp/actuators/machineset/controller_test.go
@@ -42,7 +42,8 @@ import (
 // A mock giving some machine type options for testing
 var mockMachineTypesFunc = func(_ string, _ string, machineType string) (*compute.MachineType, error) {
 	switch machineType {
-	case "n1-standard-2":
+	// t2a-standard-2 is an arm64 instance type, but this information is not provided by the compute.MachineType struct
+	case "n1-standard-2", "t2a-standard-2":
 		return &compute.MachineType{
 			GuestCpus: 2,
 			MemoryMb:  7680,
@@ -161,6 +162,18 @@ var _ = Describe("Reconciler", func() {
 				cpuKey:    "2",
 				memoryKey: "7680",
 				gpuKey:    "0",
+				labelsKey: "kubernetes.io/arch=amd64",
+			},
+			expectedEvents: []string{},
+		}),
+		Entry("with a t2a-standard-2 (arm64)", reconcileTestCase{
+			machineType:         "t2a-standard-2",
+			existingAnnotations: make(map[string]string),
+			expectedAnnotations: map[string]string{
+				cpuKey:    "2",
+				memoryKey: "7680",
+				gpuKey:    "0",
+				labelsKey: "kubernetes.io/arch=arm64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -172,6 +185,7 @@ var _ = Describe("Reconciler", func() {
 				cpuKey:    "2",
 				memoryKey: "7680",
 				gpuKey:    "2",
+				labelsKey: "kubernetes.io/arch=amd64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -182,6 +196,7 @@ var _ = Describe("Reconciler", func() {
 				cpuKey:    "16",
 				memoryKey: "16384",
 				gpuKey:    "0",
+				labelsKey: "kubernetes.io/arch=amd64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -192,6 +207,7 @@ var _ = Describe("Reconciler", func() {
 				cpuKey:    "24",
 				memoryKey: "174080",
 				gpuKey:    "2",
+				labelsKey: "kubernetes.io/arch=amd64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -207,6 +223,7 @@ var _ = Describe("Reconciler", func() {
 				cpuKey:     "2",
 				memoryKey:  "7680",
 				gpuKey:     "0",
+				labelsKey:  "kubernetes.io/arch=amd64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -295,6 +312,20 @@ func TestReconcile(t *testing.T) {
 				cpuKey:    "2",
 				memoryKey: "7680",
 				gpuKey:    "0",
+				labelsKey: "kubernetes.io/arch=amd64",
+			},
+			expectErr: false,
+		},
+		{
+			name:                "with a t2a-standard-2 (arm64)",
+			machineType:         "t2a-standard-2",
+			mockMachineTypesGet: mockMachineTypesFunc,
+			existingAnnotations: make(map[string]string),
+			expectedAnnotations: map[string]string{
+				cpuKey:    "2",
+				memoryKey: "7680",
+				gpuKey:    "0",
+				labelsKey: "kubernetes.io/arch=arm64",
 			},
 			expectErr: false,
 		},
@@ -308,6 +339,7 @@ func TestReconcile(t *testing.T) {
 				cpuKey:    "2",
 				memoryKey: "7680",
 				gpuKey:    "2",
+				labelsKey: "kubernetes.io/arch=amd64",
 			},
 			expectErr: false,
 		},
@@ -320,6 +352,7 @@ func TestReconcile(t *testing.T) {
 				cpuKey:    "16",
 				memoryKey: "16384",
 				gpuKey:    "0",
+				labelsKey: "kubernetes.io/arch=amd64",
 			},
 			expectErr: false,
 		},
@@ -332,6 +365,7 @@ func TestReconcile(t *testing.T) {
 				cpuKey:    "24",
 				memoryKey: "174080",
 				gpuKey:    "2",
+				labelsKey: "kubernetes.io/arch=amd64",
 			},
 			expectErr: false,
 		},
@@ -349,6 +383,7 @@ func TestReconcile(t *testing.T) {
 				cpuKey:     "2",
 				memoryKey:  "7680",
 				gpuKey:     "0",
+				labelsKey:  "kubernetes.io/arch=amd64",
 			},
 			expectErr: false,
 		},

--- a/pkg/cloud/gcp/actuators/util/gcp_machine_architecture.go
+++ b/pkg/cloud/gcp/actuators/util/gcp_machine_architecture.go
@@ -1,0 +1,41 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "strings"
+
+type NormalizedArch string
+
+const (
+	// ArchitectureAmd64 is the normalized architecture name for amd64.
+	ArchitectureAmd64 NormalizedArch = "amd64"
+	// ArchitectureArm64 is the normalized architecture name for arm64.
+	ArchitectureArm64 NormalizedArch = "arm64"
+)
+
+// machineTypePrefixArchitectureMap contains a map of (machineTypePrefix, architecture) tuples
+var machineTypePrefixArchitectureMap = map[string]NormalizedArch{
+	"t2a": ArchitectureArm64,
+}
+
+// CPUArchitecture gets a machineType string parameter and returns the architecture for the machineType, if it is known
+// and stored in the machineTypePrefixArchitectureMap. Otherwise, it returns amd64.
+func CPUArchitecture(machineType string) NormalizedArch {
+	prefix, _, _ := strings.Cut(machineType, "-")
+	if arch, ok := machineTypePrefixArchitectureMap[prefix]; ok {
+		return arch
+	}
+	// Fallback to Amd64 for any unknown machine types prefixes
+	return ArchitectureAmd64
+}

--- a/pkg/cloud/gcp/actuators/util/gcp_machine_architecture_test.go
+++ b/pkg/cloud/gcp/actuators/util/gcp_machine_architecture_test.go
@@ -1,0 +1,36 @@
+package util
+
+import "testing"
+
+func TestCPUArchitecture(t *testing.T) {
+	type args struct {
+		machineType string
+	}
+	tests := []struct {
+		name string
+		args args
+		want NormalizedArch
+	}{
+		{
+			name: "should return arm64 for t2a-* machine types",
+			args: args{
+				machineType: "t2a-standard-8",
+			},
+			want: ArchitectureArm64,
+		},
+		{
+			name: "should return amd64 for unknown machine types as fallback (n2-standard-8)",
+			args: args{
+				machineType: "n2-standard-8",
+			},
+			want: ArchitectureAmd64,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CPUArchitecture(tt.args.machineType); got != tt.want {
+				t.Errorf("CPUArchitecture() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a facility to support arch-aware autoscale from zero in multiarch compute clusters.
Since the gcloud API does not provide the architecture information from a give machine type, we define a map of pairs `(prefix, architecture)`. If a known pair is available, the labels' capacity annotation is set to the appropriate architecture. Otherwise, the capacity labels annotation will set to `kubernetes.io/arch=amd64`

Today, GCP provides `arm64` machine types with the `t2a-` prefix. The drawback of this implementation is the need to maintain the map in future when new machine types could be added.

cc @Prashanth684

I'm not sure this path can be viable. I found other code in this actuator that leverages checks on the machine type prefixes to perform some actions (for example, https://github.com/aleskandro/machine-api-provider-gcp/blob/41599ce77bfb7689dab017af80e7b8afd9c0a890/pkg/cloud/gcp/actuators/machine/reconciler.go#L133-L149). Opening the PR to discuss together wheter possible or to look at other solutions, if any.


Could you have a look at [this diff](https://github.com/openshift/machine-api-provider-gcp/pull/60/commits/96bfd90c0eae727fb85ba47cfb7ef6ba0b34c770)?