### PR TITLE
OCPBUGS-2117: Add extra check to termination handler

### DIFF
--- a/pkg/termination/termination_test.go
+++ b/pkg/termination/termination_test.go
@@ -143,6 +143,8 @@ var _ = Describe("Handler Suite", func() {
 
 		Context("and the handler is stopped", func() {
 			JustBeforeEach(func() {
+				// these tests need the endpoint to return a non-terminated instance response
+				counter = 0
 				close(stop)
 			})
 


### PR DESCRIPTION
This change adds an extra check the termination handler so that it can try one more time after having the context cancelled.  It is needed to fix a race condition where the termination signal can be missed and the machine is not properly marked for removal.

This change also fixes a few deprecated calls in the termination handler.