### PR TITLE
OCPBUGS-17079: Disable shielded VMs when upgrading on GCP marketplace

### DIFF
--- a/pkg/cloud/gcp/actuators/machineset/controller_test.go
+++ b/pkg/cloud/gcp/actuators/machineset/controller_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Reconciler", func() {
 	}
 
 	DescribeTable("when reconciling MachineSets", func(rtc reconcileTestCase) {
-		machineSet, err := newTestMachineSet(namespace.Name, rtc.machineType, rtc.guestAccelerators, rtc.existingAnnotations)
+		machineSet, err := newTestMachineSet(namespace.Name, rtc.machineType, rtc.guestAccelerators, rtc.existingAnnotations, nil)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(c.Create(ctx, machineSet)).To(Succeed())
@@ -420,7 +420,7 @@ func TestReconcile(t *testing.T) {
 				},
 			}
 
-			machineSet, err := newTestMachineSet("default", tc.machineType, tc.guestAccelerators, tc.existingAnnotations)
+			machineSet, err := newTestMachineSet("default", tc.machineType, tc.guestAccelerators, tc.existingAnnotations, nil)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			_, err = r.reconcile(machineSet)
@@ -430,7 +430,64 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-func newTestMachineSet(namespace string, machineType string, guestAccelerators []machinev1.GCPGPUConfig, existingAnnotations map[string]string) (*machinev1.MachineSet, error) {
+func TestReconcileDisks(t *testing.T) {
+	testCases := []struct {
+		name           string
+		disks          []*machinev1.GCPDisk
+		expectDisabled bool
+	}{
+		{
+			name: "boot disk without UEFI",
+			disks: []*machinev1.GCPDisk{
+				{Boot: true},
+			},
+			expectDisabled: true,
+		},
+		{
+			name: "boot disk with UEFI",
+			disks: []*machinev1.GCPDisk{
+				{Boot: true, Image: "uefi"},
+			},
+			expectDisabled: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			g := NewWithT(tt)
+			machineSet, err := newTestMachineSet("default", "n1-standard-2", nil, make(map[string]string), tc.disks)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			_, service := computeservice.NewComputeServiceMock()
+			service.MockMachineTypesGet = mockMachineTypesFunc
+			r := &Reconciler{
+				recorder: record.NewFakeRecorder(1),
+				cache:    newMachineTypesCache(),
+				getGCPService: func(_ string, _ machinev1.GCPMachineProviderSpec) (computeservice.GCPComputeService, error) {
+					return service, nil
+				},
+			}
+
+			_, err = r.reconcile(machineSet)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			providerConfig, err := getproviderConfig(machineSet)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			if tc.expectDisabled {
+				g.Expect(providerConfig.ShieldedInstanceConfig.SecureBoot).To(Equal(machinev1.SecureBootPolicyDisabled))
+				g.Expect(providerConfig.ShieldedInstanceConfig.IntegrityMonitoring).To(Equal(machinev1.IntegrityMonitoringPolicyDisabled))
+				g.Expect(providerConfig.ShieldedInstanceConfig.VirtualizedTrustedPlatformModule).To(Equal(machinev1.VirtualizedTrustedPlatformModulePolicyDisabled))
+			}
+
+			if !tc.expectDisabled {
+				g.Expect(providerConfig.ShieldedInstanceConfig).To(BeEquivalentTo(machinev1.GCPShieldedInstanceConfig{}))
+			}
+
+		})
+	}
+}
+
+func newTestMachineSet(namespace string, machineType string, guestAccelerators []machinev1.GCPGPUConfig, existingAnnotations map[string]string, disks []*machinev1.GCPDisk) (*machinev1.MachineSet, error) {
 	// Copy anntotations map so we don't modify the input
 	annotations := make(map[string]string)
 	for k, v := range existingAnnotations {
@@ -440,6 +497,7 @@ func newTestMachineSet(namespace string, machineType string, guestAccelerators [
 	machineProviderSpec := &machinev1.GCPMachineProviderSpec{
 		MachineType: machineType,
 		GPUs:        guestAccelerators,
+		Disks:       disks,
 	}
 	providerSpec, err := providerSpecFromMachine(machineProviderSpec)
 	if err != nil {

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -28,6 +28,7 @@ type GCPComputeService interface {
 	RegionGet(project string, region string) (*compute.Region, error)
 	GPUCompatibleMachineTypesList(project string, zone string, ctx context.Context) (map[string]int64, []string)
 	AcceleratorTypeGet(project string, zone string, acceleratorType string) (*compute.AcceleratorType, error)
+	ImageGet(project string, image string) (*compute.Image, error)
 	InstanceGroupsListInstances(project string, zone string, instanceGroup string, request *compute.InstanceGroupsListInstancesRequest) (*compute.InstanceGroupsListInstances, error)
 	InstanceGroupsAddInstances(project string, zone string, instance string, instanceGroup string) (*compute.Operation, error)
 	InstanceGroupsRemoveInstances(project string, zone string, instance string, instanceGroup string) (*compute.Operation, error)
@@ -190,4 +191,8 @@ func (c *computeService) AddInstanceGroupToBackendService(project string, region
 
 func (c *computeService) BackendServiceGet(project string, region string, backendServiceName string) (*compute.BackendService, error) {
 	return c.service.RegionBackendServices.Get(project, region, backendServiceName).Do()
+}
+
+func (c *computeService) ImageGet(project string, image string) (*compute.Image, error) {
+	return c.service.Images.Get(project, image).Do()
 }

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/util"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
@@ -21,6 +22,7 @@ const (
 	ErrGettingBackendService       = "errGettingBackendService"
 	ErrFailGroupGet                = "errFailGroupGet"
 	ErrGroupNotFound               = "errGroupNotFound"
+	ErrImageNotFound               = "errImageNotFound"
 	PatchBackendService            = "patchBackendService"
 	AddGroupSuccessfully           = "addGroupSuccessfully"
 )
@@ -246,4 +248,20 @@ func (c *GCPComputeServiceMock) BackendServiceGet(project string, region string,
 			},
 		},
 	}, nil
+}
+
+func (c *GCPComputeServiceMock) ImageGet(project string, image string) (*compute.Image, error) {
+	if project == ErrImageNotFound {
+		return nil, errors.New("imageGet request failed")
+	}
+
+	img := &compute.Image{
+		GuestOsFeatures: make([]*compute.GuestOsFeature, 0),
+	}
+
+	if image == "uefi" {
+		img.GuestOsFeatures = append(img.GuestOsFeatures, &compute.GuestOsFeature{Type: util.UEFICompatible})
+	}
+
+	return img, nil
 }

--- a/pkg/cloud/gcp/actuators/util/register.go
+++ b/pkg/cloud/gcp/actuators/util/register.go
@@ -10,6 +10,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	UEFICompatible = "UEFI_COMPATIBLE"
+)
+
 // RawExtensionFromProviderSpec marshals the machine provider spec.
 func RawExtensionFromProviderSpec(spec *machinev1.GCPMachineProviderSpec) (*runtime.RawExtension, error) {
 	if spec == nil {


### PR DESCRIPTION
The GCP marketplace images are not updated frequently, and the 4.12 release used a 4.8 image. This image was created without support for UEFI, which is [required for shielded VM support](https://cloud.google.com/compute/shielded-vm/docs/creating-shielded-images#preparing-the-disk). When upgrading to OpenShift 4.13, shielded VM support is enabled by default. However, this older image and the defaults cause an error, meaning new Machines will not boot.

This is fixed by detecting whether or not a disk is UEFI-compatible and setting the MachineSet's ProviderConfig.ShieldedInstanceConfig to disable shielded VMs when UEFI is not supported.