### PR TITLE
CORS-3739: Add c4a instance as arm type

### DIFF
--- a/pkg/cloud/gcp/actuators/util/gcp_machine_architecture.go
+++ b/pkg/cloud/gcp/actuators/util/gcp_machine_architecture.go
@@ -26,6 +26,7 @@ const (
 
 // machineTypePrefixArchitectureMap contains a map of (machineTypePrefix, architecture) tuples
 var machineTypePrefixArchitectureMap = map[string]NormalizedArch{
+	"c4a": ArchitectureArm64,
 	"t2a": ArchitectureArm64,
 }
 


### PR DESCRIPTION
** The c4a instance type needs to be added for other projects that import this package and its validation. Added the c4a instance type as an ARM type to the dictionary for lookup.