### PR TITLE
[release-4.17] OCPBUGS-46082: update a2 gpu detection logic to be dynamic

### DIFF
--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -149,7 +149,7 @@ func (c *GCPComputeServiceMock) RegionGet(project string, region string) (*compu
 	return &compute.Region{Quotas: nil}, nil
 }
 
-func (c *GCPComputeServiceMock) GPUCompatibleMachineTypesList(project string, zone string, ctx context.Context) (map[string]int64, []string) {
+func (c *GCPComputeServiceMock) GPUCompatibleMachineTypesList(project string, zone string, ctx context.Context) (map[string]GpuInfo, []string) {
 	var compatibleMachineType = []string{"n1-test-machineType"}
 	return nil, compatibleMachineType
 }


### PR DESCRIPTION
this change updates the way that a2 instance types are validated for quota. gcp has added a new type of a2 instance category named "ultragpu". the ultragpu series has a different type of gpu, "nvidia-a100-80gb", which requires a new constant be applied to the quota.

to make this workflow more modular in the future, it is also being adjusted to dynamically discover the gpu type during the instance quota validation.