### PR TITLE
OCPBUGS-46387: add a3 instance types to gpu quota validation logic

### DIFF
--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -125,17 +125,17 @@ type GpuInfo struct {
 	Type  string
 }
 
-// GPUCompatibleMachineTypesList function lists machineTypes available in the zone and return map of A2 family and slice of N1 family machineTypes
+// GPUCompatibleMachineTypesList function lists machineTypes available in the zone and return map of A2 and A3 family and slice of N1 family machineTypes
 func (c *computeService) GPUCompatibleMachineTypesList(project string, zone string, ctx context.Context) (map[string]GpuInfo, []string) {
 	req := c.service.MachineTypes.List(project, zone)
 	var (
-		a2MachineFamily = map[string]GpuInfo{}
-		n1MachineFamily []string
+		a2or3MachineFamily = map[string]GpuInfo{}
+		n1MachineFamily    []string
 	)
 	if err := req.Pages(ctx, func(page *compute.MachineTypeList) error {
 		for _, machineType := range page.Items {
-			if strings.HasPrefix(machineType.Name, "a2") {
-				a2MachineFamily[machineType.Name] = GpuInfo{
+			if strings.HasPrefix(machineType.Name, "a2") || strings.HasPrefix(machineType.Name, "a3") {
+				a2or3MachineFamily[machineType.Name] = GpuInfo{
 					Count: machineType.Accelerators[0].GuestAcceleratorCount,
 					Type:  machineType.Accelerators[0].GuestAcceleratorType,
 				}
@@ -147,7 +147,7 @@ func (c *computeService) GPUCompatibleMachineTypesList(project string, zone stri
 	}); err != nil {
 		log.Fatal(err)
 	}
-	return a2MachineFamily, n1MachineFamily
+	return a2or3MachineFamily, n1MachineFamily
 }
 
 func (c *computeService) AcceleratorTypeGet(project string, zone string, acceleratorType string) (*compute.AcceleratorType, error) {


### PR DESCRIPTION
this change expands the quota detection logic to include a3 instance types in addition to a2.