### PR TITLE
CORS-3906: Update MAPI GCP Provider to use custom GCP endpoints

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -84,7 +84,7 @@ func main() {
 
 	// Sets up feature gates
 	defaultMutableGate := feature.DefaultMutableFeatureGate
-	gateOpts, err := features.NewFeatureGateOptions(defaultMutableGate, apifeatures.SelfManaged, apifeatures.FeatureGateMachineAPIMigration)
+	gateOpts, err := features.NewFeatureGateOptions(defaultMutableGate, apifeatures.SelfManaged, apifeatures.FeatureGateMachineAPIMigration, apifeatures.FeatureGateGCPCustomAPIEndpoints)
 	if err != nil {
 		klog.Fatalf("Error setting up feature gates: %v", err)
 	}
@@ -173,8 +173,9 @@ func main() {
 	ctrl.SetLogger(klogr.New())
 	setupLog := ctrl.Log.WithName("setup")
 	if err = (&machinesetcontroller.Reconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("MachineSet"),
+		Client:       mgr.GetClient(),
+		Log:          ctrl.Log.WithName("controllers").WithName("MachineSet"),
+		FeatureGates: defaultMutableGate,
 	}).SetupWithManager(mgr, controller.Options{}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MachineSet")
 		os.Exit(1)

--- a/pkg/cloud/gcp/actuators/machine/actuator.go
+++ b/pkg/cloud/gcp/actuators/machine/actuator.go
@@ -10,6 +10,7 @@ import (
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	computeservice "github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/services/compute"
 	tagservice "github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/services/tags"
+	"github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/featuregate"
@@ -34,6 +35,7 @@ type Actuator struct {
 	computeClientBuilder computeservice.BuilderFuncType
 	tagsClientBuilder    tagservice.BuilderFuncType
 	featureGates         featuregate.FeatureGate
+	endpointLookup       util.EndpointLookupFuncType
 }
 
 // ActuatorParams holds parameter information for Actuator.
@@ -43,6 +45,7 @@ type ActuatorParams struct {
 	ComputeClientBuilder computeservice.BuilderFuncType
 	TagsClientBuilder    tagservice.BuilderFuncType
 	FeatureGates         featuregate.FeatureGate
+	EndpointLookup       util.EndpointLookupFuncType
 }
 
 // NewActuator returns an actuator.
@@ -53,6 +56,7 @@ func NewActuator(params ActuatorParams) *Actuator {
 		computeClientBuilder: params.ComputeClientBuilder,
 		tagsClientBuilder:    params.TagsClientBuilder,
 		featureGates:         params.FeatureGates,
+		endpointLookup:       params.EndpointLookup,
 	}
 }
 
@@ -76,6 +80,7 @@ func (a *Actuator) Create(ctx context.Context, machine *machinev1.Machine) error
 		computeClientBuilder: a.computeClientBuilder,
 		tagsClientBuilder:    a.tagsClientBuilder,
 		featureGates:         a.featureGates,
+		endpointLookup:       a.endpointLookup,
 	})
 	if err != nil {
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)
@@ -100,6 +105,7 @@ func (a *Actuator) Exists(ctx context.Context, machine *machinev1.Machine) (bool
 		computeClientBuilder: a.computeClientBuilder,
 		tagsClientBuilder:    a.tagsClientBuilder,
 		featureGates:         a.featureGates,
+		endpointLookup:       a.endpointLookup,
 	})
 	if err != nil {
 		return false, fmt.Errorf(scopeFailFmt, machine.Name, err)
@@ -141,6 +147,7 @@ func (a *Actuator) Update(ctx context.Context, machine *machinev1.Machine) error
 		computeClientBuilder: a.computeClientBuilder,
 		tagsClientBuilder:    a.tagsClientBuilder,
 		featureGates:         a.featureGates,
+		endpointLookup:       a.endpointLookup,
 	})
 	if err != nil {
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)
@@ -178,6 +185,7 @@ func (a *Actuator) Delete(ctx context.Context, machine *machinev1.Machine) error
 		computeClientBuilder: a.computeClientBuilder,
 		tagsClientBuilder:    a.tagsClientBuilder,
 		featureGates:         a.featureGates,
+		endpointLookup:       a.endpointLookup,
 	})
 	if err != nil {
 		fmtErr := fmt.Errorf(scopeFailFmt, machine.GetName(), err)

--- a/pkg/cloud/gcp/actuators/machine/actuator_test.go
+++ b/pkg/cloud/gcp/actuators/machine/actuator_test.go
@@ -320,6 +320,7 @@ func TestActuatorEvents(t *testing.T) {
 				ComputeClientBuilder: computeservice.MockBuilderFuncType,
 				TagsClientBuilder:    tagservice.NewMockTagServiceBuilder,
 				FeatureGates:         gate,
+				EndpointLookup:       util.MockGCPEndpointLookup,
 			}
 
 			actuator := NewActuator(params)
@@ -424,6 +425,7 @@ func TestActuatorExists(t *testing.T) {
 				ComputeClientBuilder: computeservice.MockBuilderFuncType,
 				TagsClientBuilder:    tagservice.NewMockTagServiceBuilder,
 				FeatureGates:         gate,
+				EndpointLookup:       util.MockGCPEndpointLookup,
 			}
 
 			actuator := NewActuator(params)
@@ -446,7 +448,7 @@ func TestActuatorExists(t *testing.T) {
 
 func NewDefaultMutableFeatureGate(gateConfig map[string]bool) (featuregate.MutableFeatureGate, error) {
 	defaultMutableGate := feature.DefaultMutableFeatureGate
-	_, err := features.NewFeatureGateOptions(defaultMutableGate, openshiftfeatures.SelfManaged, openshiftfeatures.FeatureGateMachineAPIMigration)
+	_, err := features.NewFeatureGateOptions(defaultMutableGate, openshiftfeatures.SelfManaged, openshiftfeatures.FeatureGateMachineAPIMigration, openshiftfeatures.FeatureGateGCPCustomAPIEndpoints)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set up default feature gate: %w", err)
 	}

--- a/pkg/cloud/gcp/actuators/machine/machine_scope_test.go
+++ b/pkg/cloud/gcp/actuators/machine/machine_scope_test.go
@@ -192,7 +192,7 @@ func TestNewMachineScope(t *testing.T) {
 			name: "fail to create compute service",
 			params: machineScopeParams{
 				coreClient: fakeClient,
-				computeClientBuilder: func(serviceAccountJSON string) (computeservice.GCPComputeService, error) {
+				computeClientBuilder: func(serviceAccountJSON string, endpoint *configv1.GCPServiceEndpoint) (computeservice.GCPComputeService, error) {
 					return nil, errors.New("test error")
 				},
 				machine: &machinev1.Machine{
@@ -221,6 +221,7 @@ func TestNewMachineScope(t *testing.T) {
 			gate, err := NewDefaultMutableFeatureGate(nil)
 			gs.Expect(err).To(Not(HaveOccurred()))
 			tc.params.featureGates = gate
+			tc.params.endpointLookup = util.MockGCPEndpointLookup
 
 			scope, err := newMachineScope(tc.params)
 
@@ -426,6 +427,7 @@ func TestPatchMachine(t *testing.T) {
 				computeClientBuilder: computeservice.MockBuilderFuncType,
 				tagsClientBuilder:    tagservice.NewMockTagServiceBuilder,
 				featureGates:         gate,
+				endpointLookup:       util.MockGCPEndpointLookup,
 			})
 
 			gs.Expect(err).ToNot(HaveOccurred())

--- a/pkg/cloud/gcp/actuators/machineset/controller.go
+++ b/pkg/cloud/gcp/actuators/machineset/controller.go
@@ -21,6 +21,8 @@ import (
 	"github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/util"
 
 	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	apifeatures "github.com/openshift/api/features"
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	mapierrors "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	mapiutil "github.com/openshift/machine-api-operator/pkg/util"
@@ -29,6 +31,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -52,6 +55,8 @@ type Reconciler struct {
 	recorder record.EventRecorder
 	scheme   *runtime.Scheme
 	cache    *machineTypesCache
+
+	FeatureGates featuregate.FeatureGate
 
 	// Allow a mock GCPComputeService to be injected during testing
 	getGCPService func(namespace string, providerConfig machinev1.GCPMachineProviderSpec) (computeservice.GCPComputeService, error)
@@ -215,7 +220,15 @@ func (r *Reconciler) getRealGCPService(namespace string, providerConfig machinev
 		return nil, err
 	}
 
-	computeService, err := computeservice.NewComputeService(serviceAccountJSON)
+	var endpoint *configv1.GCPServiceEndpoint = nil
+	if r.FeatureGates.Enabled(featuregate.Feature(apifeatures.FeatureGateGCPCustomAPIEndpoints)) {
+		endpoint, err = util.GetGCPServiceEndpoint(r.Client, configv1.GCPServiceEndpointNameCompute)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get GCP compute service endpoint: %v", err)
+		}
+	}
+
+	computeService, err := computeservice.NewComputeService(serviceAccountJSON, endpoint)
 	if err != nil {
 		return nil, mapierrors.InvalidMachineConfiguration("error creating compute service: %v", err)
 	}

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/machine-api-provider-gcp/pkg/version"
 	"google.golang.org/api/compute/v1"
 )
@@ -44,10 +45,10 @@ type computeService struct {
 }
 
 // BuilderFuncType is function type for building gcp client
-type BuilderFuncType func(serviceAccountJSON string) (GCPComputeService, error)
+type BuilderFuncType func(serviceAccountJSON string, endpoint *configv1.GCPServiceEndpoint) (GCPComputeService, error)
 
 // NewComputeService return a new computeService
-func NewComputeService(serviceAccountJSON string) (GCPComputeService, error) {
+func NewComputeService(serviceAccountJSON string, endpoint *configv1.GCPServiceEndpoint) (GCPComputeService, error) {
 	ctx := context.TODO()
 
 	creds, err := google.CredentialsFromJSON(ctx, []byte(serviceAccountJSON), compute.CloudPlatformScope)
@@ -55,7 +56,14 @@ func NewComputeService(serviceAccountJSON string) (GCPComputeService, error) {
 		return nil, err
 	}
 
-	service, err := compute.NewService(ctx, option.WithCredentials(creds))
+	options := []option.ClientOption{
+		option.WithCredentials(creds),
+	}
+	if endpoint != nil && endpoint.URL != "" {
+		options = append(options, option.WithEndpoint(endpoint.URL))
+	}
+
+	service, err := compute.NewService(ctx, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -7,6 +7,8 @@ import (
 
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 const (
@@ -132,12 +134,12 @@ func NewComputeServiceMock() (*compute.Instance, *GCPComputeServiceMock) {
 	return &receivedInstance, &computeServiceMock
 }
 
-func MockBuilderFuncType(serviceAccountJSON string) (GCPComputeService, error) {
+func MockBuilderFuncType(serviceAccountJSON string, endpoint *configv1.GCPServiceEndpoint) (GCPComputeService, error) {
 	_, computeSvc := NewComputeServiceMock()
 	return computeSvc, nil
 }
 
-func MockBuilderFuncTypeNotFound(serviceAccountJSON string) (GCPComputeService, error) {
+func MockBuilderFuncTypeNotFound(serviceAccountJSON string, endpoint *configv1.GCPServiceEndpoint) (GCPComputeService, error) {
 	_, computeSvc := NewComputeServiceMock()
 	computeSvc.mockInstancesGet = func(project string, zone string, instance string) (*compute.Instance, error) {
 		return nil, &googleapi.Error{

--- a/pkg/cloud/gcp/actuators/services/tags/tagservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/tags/tagservice_mock.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	tags "google.golang.org/api/cloudresourcemanager/v3"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 // MockTagService mocks TagService interface for tests.
@@ -17,7 +19,7 @@ func NewMockTagService() *MockTagService {
 }
 
 // NewMockTagServiceBuilder returns new mock for creating GCP tag client.
-func NewMockTagServiceBuilder(ctx context.Context, serviceAccountJSON string) (TagService, error) {
+func NewMockTagServiceBuilder(ctx context.Context, serviceAccountJSON string, endpoint *configv1.GCPServiceEndpoint) (TagService, error) {
 	return NewMockTagService(), nil
 }
 

--- a/pkg/cloud/gcp/actuators/util/gcp_endpoints.go
+++ b/pkg/cloud/gcp/actuators/util/gcp_endpoints.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"fmt"
+
+	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// EndpointLookupFuncType is function type for finding overridden gcp service endpoints
+type EndpointLookupFuncType func(client controllerclient.Client, endpointName configv1.GCPServiceEndpointName) (*configv1.GCPServiceEndpoint, error)
+
+// GetGCPServiceEndpoint finds the GCP Service Endpoint override information for a provided service.
+func GetGCPServiceEndpoint(client controllerclient.Client, endpointName configv1.GCPServiceEndpointName) (*configv1.GCPServiceEndpoint, error) {
+	infra, err := GetInfrastructure(client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster infrastructure: %w", err)
+	}
+
+	if infra != nil && infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.GCP != nil {
+		for _, endpoint := range infra.Status.PlatformStatus.GCP.ServiceEndpoints {
+			if endpoint.Name == endpointName {
+				return &endpoint, nil
+			}
+		}
+	}
+	return nil, nil
+}

--- a/pkg/cloud/gcp/actuators/util/gcp_endpoints_mock.go
+++ b/pkg/cloud/gcp/actuators/util/gcp_endpoints_mock.go
@@ -1,0 +1,12 @@
+package util
+
+import (
+	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// GetGCPServiceEndpoint finds the GCP Service Endpoint override information for a provided service.
+func MockGCPEndpointLookup(client controllerclient.Client, endpointName configv1.GCPServiceEndpointName) (*configv1.GCPServiceEndpoint, error) {
+	return nil, nil
+}


### PR DESCRIPTION
** Vendor update. Update openshift/api to use a version that contains the custom endpoint information.

** When creating the compute service, determine if there is a custom endpoint set in the infrastructure platform status.
** When creating the tagging service, determine fi there is a custom endpoint set in the infrastructure platform status.
** Add a function template to pass to the actuator and machine scope parameters for looking up the custom endpoints. During tests a Mock function is passed that will do nothing and return no error. During the actual execution the real lookup function is passed. When no function is set the default will be to use the function that will look through the infrastructure to find the custom endpoints.
** Update machine scope tests to set a mock function.
** Update actuator tests to set a mock function