### PR TITLE
CORS-3906: Update custom endpoint configuration

### DIFF
--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -59,15 +59,16 @@ func NewComputeService(serviceAccountJSON string, endpoint *configv1.GCPServiceE
 	options := []option.ClientOption{
 		option.WithCredentials(creds),
 	}
-	if endpoint != nil && endpoint.URL != "" {
-		options = append(options, option.WithEndpoint(endpoint.URL))
-	}
 
 	service, err := compute.NewService(ctx, options...)
 	if err != nil {
 		return nil, err
 	}
 	service.UserAgent = "gcpprovider.openshift.io/" + version.Version.String()
+
+	if endpoint != nil && endpoint.URL != "" {
+		service.BasePath = endpoint.URL
+	}
 
 	return &computeService{
 		service: service,

--- a/pkg/cloud/gcp/actuators/services/tags/tagservice.go
+++ b/pkg/cloud/gcp/actuators/services/tags/tagservice.go
@@ -29,13 +29,14 @@ func NewTagService(ctx context.Context, serviceAccountJSON string, endpoint *con
 	options := []option.ClientOption{
 		option.WithCredentialsJSON([]byte(serviceAccountJSON)),
 	}
-	if endpoint != nil && endpoint.URL != "" {
-		options = append(options, option.WithEndpoint(endpoint.URL))
-	}
 
 	service, err := tags.NewService(ctx, options...)
 	if err != nil {
 		return nil, fmt.Errorf("could not create new tag service: %w", err)
+	}
+
+	if endpoint != nil && endpoint.URL != "" {
+		service.BasePath = endpoint.URL
 	}
 
 	return &tagService{


### PR DESCRIPTION
If a custom service endpoint has been sent in for a service, use it during service creation. When this was originally completed, the option.WithEndpoint Google cloud option was used. This is the offically accepted way that is recommended by Google. However, it was discovered that when an endpoint formatted as https://someendpoint... is used, the client was producing 404 errors. If this same endpoint was used but set with BasePath = endpoint the correct endpoint was used and traffic was observed going to the endpoint.

This feature is behind the "GCPCustomAPIEndpoints" featuregate.