### PR TITLE
OCPBUGS-46387: allow instances with unknown quotas to be created

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -113,6 +113,7 @@ func (r *Reconciler) checkQuota(guestAccelerators []machinev1.GCPGPUConfig) erro
 	if r.providerSpec.Preemptible {
 		metric = "PREEMPTIBLE_" + metric
 	}
+
 	// check quota for GA
 	for i, q := range quotas {
 		if q.Metric == metric {
@@ -121,8 +122,15 @@ func (r *Reconciler) checkQuota(guestAccelerators []machinev1.GCPGPUConfig) erro
 			}
 			break
 		}
+		// in some cases, we cannot detect the quota for a machine type. in these cases we want to allow the creation with a warning to the user.
 		if i == len(quotas)-1 {
-			return machinecontroller.InvalidMachineConfiguration(fmt.Sprintf("No quota found. Metric: %s.", metric))
+			klog.Warningf("No quota found for metric %s, allowing creation of machine type %s with %s type accelerator in region %s and zone %s. This may result in a failed instance.",
+				metric,
+				r.providerSpec.MachineType,
+				accelerator.Type,
+				r.providerSpec.Region,
+				r.providerSpec.Zone,
+			)
 		}
 	}
 	return nil

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -30,10 +30,12 @@ const (
 )
 
 type GCPComputeServiceMock struct {
-	MockInstancesInsert   func(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
-	MockMachineTypesGet   func(project string, zone string, machineType string) (*compute.MachineType, error)
-	mockZoneOperationsGet func(project string, zone string, operation string) (*compute.Operation, error)
-	mockInstancesGet      func(project string, zone string, instance string) (*compute.Instance, error)
+	MockGPUCompatibleMachineTypesList func(project string, zone string, ctx context.Context) (map[string]GpuInfo, []string)
+	MockInstancesInsert               func(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
+	MockMachineTypesGet               func(project string, zone string, machineType string) (*compute.MachineType, error)
+	MockRegionGet                     func(project string, region string) (*compute.Region, error)
+	mockZoneOperationsGet             func(project string, zone string, operation string) (*compute.Operation, error)
+	mockInstancesGet                  func(project string, zone string, instance string) (*compute.Instance, error)
 }
 
 func (c *GCPComputeServiceMock) InstancesInsert(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
@@ -150,13 +152,22 @@ func MockBuilderFuncTypeNotFound(serviceAccountJSON string, endpoint *configv1.G
 }
 
 func (c *GCPComputeServiceMock) RegionGet(project string, region string) (*compute.Region, error) {
-	return &compute.Region{Quotas: nil}, nil
+	if c.MockRegionGet == nil {
+		return &compute.Region{Quotas: nil}, nil
+	}
+
+	return c.MockRegionGet(project, region)
 }
 
 func (c *GCPComputeServiceMock) GPUCompatibleMachineTypesList(project string, zone string, ctx context.Context) (map[string]GpuInfo, []string) {
-	var compatibleMachineType = []string{"n1-test-machineType"}
-	return nil, compatibleMachineType
+	if c.MockGPUCompatibleMachineTypesList == nil {
+		var compatibleMachineType = []string{"n1-test-machineType"}
+		return nil, compatibleMachineType
+	}
+
+	return c.MockGPUCompatibleMachineTypesList(project, zone, ctx)
 }
+
 func (c *GCPComputeServiceMock) AcceleratorTypeGet(project string, zone string, acceleratorType string) (*compute.AcceleratorType, error) {
 	return nil, nil
 }


### PR DESCRIPTION
this change relaxes some of the quota checking logic so that if a
specific metric is not detecting in the list of quotas for a region, the
controller will emit a log warning but allow the creation of the
instance.

this is being introduced to help solve issues where the google apis do
not return regional information for some attached gpus, such as
NVIDIA_H100_GPU.