### PR TITLE
[release-4.16] OCPBUGS-55249: Disable shielded VMs for non-UEFI disks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/onsi/gomega v1.31.1
 	github.com/openshift/api v0.0.0-20240124164020-e2ce40831f2e
 	github.com/openshift/client-go v0.0.0-20240115204758-e6bf7d631d5e
+	github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20250425124313-1c5f483c5fb7
 	github.com/openshift/library-go v0.0.0-20240116081341-964bcb3f545c
 	github.com/openshift/machine-api-operator v0.2.1-0.20240125175440-c9de8bda0dd1
 	golang.org/x/oauth2 v0.12.0
@@ -99,7 +100,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
-	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 // indirect
+	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -277,6 +277,8 @@ github.com/openshift/api v0.0.0-20240124164020-e2ce40831f2e h1:cxgCNo/R769CO23AK
 github.com/openshift/api v0.0.0-20240124164020-e2ce40831f2e/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openshift/client-go v0.0.0-20240115204758-e6bf7d631d5e h1:qGjfKX8i0h4efMNEnhgTdxcdx6gwwOwhTfBJ20WFqA8=
 github.com/openshift/client-go v0.0.0-20240115204758-e6bf7d631d5e/go.mod h1:2am3qrggh9LlDCf/MDGzcFWMhdaushxFQi0+ZZDhdVk=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20250425124313-1c5f483c5fb7 h1:3yXoLaMFsD+xvGWjySZIWY6C3GThKUNB0N2XJWB9Peg=
+github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20250425124313-1c5f483c5fb7/go.mod h1:osVq9/R6qKHBQxDP4cYTvkgXVBKOMs1SOfPLFfn0m7A=
 github.com/openshift/library-go v0.0.0-20240116081341-964bcb3f545c h1:gLylEQQryG+A6nqWYIwE1wUzn1eFUmthjADvflMWKnM=
 github.com/openshift/library-go v0.0.0-20240116081341-964bcb3f545c/go.mod h1:82B0gt8XawdXWRtKMrm3jSMTeRsiOSYKCi4F0fvPjG0=
 github.com/openshift/machine-api-operator v0.2.1-0.20240125175440-c9de8bda0dd1 h1:evsu59B17Bl1tT+eLUjuzh8ux/iXJv4/94tQlOF+a6Q=
@@ -372,8 +374,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=
-golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea h1:vLCWI/yYrdEHyN2JzIzPO3aaQJHQdp89IZBA/+azVC4=
+golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/cloud/gcp/actuators/machine/actuator_test.go
+++ b/pkg/cloud/gcp/actuators/machine/actuator_test.go
@@ -120,6 +120,12 @@ func TestActuatorEvents(t *testing.T) {
 		CredentialsSecret: &corev1.LocalObjectReference{
 			Name: credentialsSecretName,
 		},
+		Disks: []*machinev1.GCPDisk{
+			{
+				Boot:  true,
+				Image: "projects/fooproject/global/images/uefi-image",
+			},
+		},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(providerSpec).ToNot(BeNil())

--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -208,6 +208,35 @@ func (r *Reconciler) create() error {
 		instance.Scheduling.AutomaticRestart = automaticRestart
 	}
 
+	// This is mostly to smooth off a rough edge, and hopefully should not be a
+	// case that is hit often. If an existing machineset has a non UEFI
+	// compatible disk, the check in the machineset controller should explicitly
+	// disable any ShieldedInstanceConfig, however, if a customer is using custom
+	// disk images that don't support UEFI and creating new machinesets we may
+	// still fail as the create() from the MAO may reconcile before the
+	// machineset reconciliation in MAPG.
+	//
+	// If the providerSpec sets any ShieldedInstanceConfig, we won't check UEFI
+	// disk compatibility.
+	if r.providerSpec.ShieldedInstanceConfig == (machinev1.GCPShieldedInstanceConfig{}) {
+		klog.V(3).Infof("No ShieldedInstanceConfig set for machine: %s, checking if disk is UEFI compatible", r.machine.Name)
+		uefiCompatible, err := util.IsUEFICompatible(r.computeService, r.providerSpec)
+		if err != nil {
+			return fmt.Errorf("error fetching disk information: %w", err)
+		}
+
+		// We do this here so we piggyback defaulting and ForceSendFields below
+		// will still work nicely.
+		if !uefiCompatible {
+			klog.Infof("Disk for machine %s is not UEFI compatible, disabling ShieldedInstanceConfig", r.machine.Name)
+			r.providerSpec.ShieldedInstanceConfig = machinev1.GCPShieldedInstanceConfig{
+				SecureBoot:                       machinev1.SecureBootPolicyDisabled,
+				VirtualizedTrustedPlatformModule: machinev1.VirtualizedTrustedPlatformModulePolicyDisabled,
+				IntegrityMonitoring:              machinev1.IntegrityMonitoringPolicyDisabled,
+			}
+		}
+	}
+
 	if r.providerSpec.ShieldedInstanceConfig.SecureBoot == machinev1.SecureBootPolicyEnabled {
 		instance.ShieldedInstanceConfig.EnableSecureBoot = true
 	}

--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -64,6 +64,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Fail on invalid user data secret",
 			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Disks: []*machinev1.GCPDisk{
+					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
+					},
+				},
 				UserDataSecret: &corev1.LocalObjectReference{
 					Name: "notvalid",
 				},
@@ -109,6 +115,12 @@ func TestCreate(t *testing.T) {
 			providerSpec: &machinev1.GCPMachineProviderSpec{
 				ProjectID: "project",
 				Region:    "test-region",
+				Disks: []*machinev1.GCPDisk{
+					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
+					},
+				},
 				NetworkInterfaces: []*machinev1.GCPNetworkInterface{
 					{
 						ProjectID:  "network-project",
@@ -143,6 +155,12 @@ func TestCreate(t *testing.T) {
 						Count: 2,
 					},
 				},
+				Disks: []*machinev1.GCPDisk{
+					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
+					},
+				},
 			},
 			validateInstance: func(t *testing.T, instance *compute.Instance) {
 				if len(instance.GuestAccelerators) != 1 {
@@ -163,6 +181,12 @@ func TestCreate(t *testing.T) {
 			providerSpec: &machinev1.GCPMachineProviderSpec{
 				ProjectID: "project",
 				Region:    "test-region",
+				Disks: []*machinev1.GCPDisk{
+					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
+					},
+				},
 				NetworkInterfaces: []*machinev1.GCPNetworkInterface{
 					{
 						Network:    "test-network",
@@ -191,6 +215,7 @@ func TestCreate(t *testing.T) {
 				Region:    "test-region",
 				Disks: []*machinev1.GCPDisk{
 					{
+						Boot: true,
 						EncryptionKey: &machinev1.GCPEncryptionKeyReference{
 							KMSKey: &machinev1.GCPKMSKeyReference{
 								Name:      "kms-key-name",
@@ -228,6 +253,8 @@ func TestCreate(t *testing.T) {
 				Region:    "test-region",
 				Disks: []*machinev1.GCPDisk{
 					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
 						EncryptionKey: &machinev1.GCPEncryptionKeyReference{
 							KMSKey: &machinev1.GCPKMSKeyReference{
 								Name:     "kms-key",
@@ -263,6 +290,12 @@ func TestCreate(t *testing.T) {
 				machinev1.MachineClusterIDLabel: "CLUSTERID",
 			},
 			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Disks: []*machinev1.GCPDisk{
+					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
+					},
+				},
 				UserDataSecret: &corev1.LocalObjectReference{
 					Name: "windows-user-data",
 				},
@@ -297,6 +330,12 @@ func TestCreate(t *testing.T) {
 				machinev1.MachineClusterIDLabel: "CLUSTERID",
 			},
 			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Disks: []*machinev1.GCPDisk{
+					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
+					},
+				},
 				Metadata: []*machinev1.GCPMetadata{
 					{
 						Key:   windowsScriptMetadataKey,
@@ -349,6 +388,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Always restart policy with a non-preemptible instance does not produce an error",
 			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Disks: []*machinev1.GCPDisk{
+					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
+					},
+				},
 				Preemptible:   false,
 				RestartPolicy: v1beta1.RestartPolicyAlways,
 			},
@@ -356,6 +401,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Never restart policy with a preemptible instance does not produce an error",
 			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Disks: []*machinev1.GCPDisk{
+					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
+					},
+				},
 				Preemptible:   true,
 				RestartPolicy: v1beta1.RestartPolicyNever,
 			},
@@ -363,6 +414,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "Never restart policy with a non-preemptible instance does not produce an error",
 			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Disks: []*machinev1.GCPDisk{
+					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
+					},
+				},
 				Preemptible:   false,
 				RestartPolicy: v1beta1.RestartPolicyNever,
 			},
@@ -386,6 +443,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "shieldedInstanceConfig not set, verify default behavior",
 			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Disks: []*machinev1.GCPDisk{
+					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
+					},
+				},
 				Region:      "test-region",
 				Zone:        "test-zone",
 				MachineType: "n1-test-machineType",
@@ -405,6 +468,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "shieldedInstanceConfig with SecureBoot enabled",
 			providerSpec: &machinev1.GCPMachineProviderSpec{
+				Disks: []*machinev1.GCPDisk{
+					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
+					},
+				},
 				Region:                 "test-region",
 				Zone:                   "test-zone",
 				MachineType:            "n1-test-machineType",
@@ -449,6 +518,12 @@ func TestCreate(t *testing.T) {
 				Zone:                "test-zone",
 				MachineType:         "n2d-standard-4",
 				ConfidentialCompute: machinev1.ConfidentialComputePolicyEnabled,
+				Disks: []*machinev1.GCPDisk{
+					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
+					},
+				},
 				ResourceManagerTags: []machinev1.ResourceManagerTag{
 					{
 						ParentID: "openshift",
@@ -507,7 +582,14 @@ func TestCreate(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			receivedInstance, mockComputeService := computeservice.NewComputeServiceMock()
-			providerSpec := &machinev1.GCPMachineProviderSpec{}
+			providerSpec := &machinev1.GCPMachineProviderSpec{
+				Disks: []*machinev1.GCPDisk{
+					{
+						Boot:  true,
+						Image: "projects/fooproject/global/images/uefi-image",
+					},
+				},
+			}
 			labels := map[string]string{
 				machinev1.MachineClusterIDLabel: "CLUSTERID",
 			}
@@ -620,6 +702,12 @@ func TestReconcileMachineWithCloudState(t *testing.T) {
 		},
 		coreClient: controllerfake.NewFakeClient(),
 		providerSpec: &machinev1.GCPMachineProviderSpec{
+			Disks: []*machinev1.GCPDisk{
+				{
+					Boot:  true,
+					Image: "projects/fooproject/global/images/uefi-image",
+				},
+			},
 			Zone: zone,
 		},
 		projectID:      projecID,

--- a/pkg/cloud/gcp/actuators/machineset/controller.go
+++ b/pkg/cloud/gcp/actuators/machineset/controller.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/util"
 
@@ -177,10 +176,12 @@ func (r *Reconciler) reconcile(machineSet *machinev1.MachineSet) (ctrl.Result, e
 		fmt.Sprintf("kubernetes.io/arch=%s", util.CPUArchitecture(providerConfig.MachineType)),
 		machineSet.Annotations[labelsKey])
 
-	// When upgrading from 4.12 on GCP marketplace, the MachineSets refer to images that do not support UEFI & shielded VMs.
-	// However, GCP defaulted to shielded VMs sometime between 4.12 and 4.13.
-	// Therefore, we should disable the shielded instance config in the MachineSet's template, so that new Machines created from it will boot.
-	uefiCompatible, err := isUEFICompatible(gceService, providerConfig)
+	// From OCP 4.13, we enable Shielded Instance Config by default. However, in
+	// some cases the boot disk is not UEFI compatible and instance creation will
+	// fail. This may present as customers being unable to scale existing
+	// machinesets. We should disable the shielded instance config in the
+	// MachineSet's template, so that new Machines created from it will boot.
+	uefiCompatible, err := util.IsUEFICompatible(gceService, providerConfig)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error fetching disk information: %s", err)
 	}
@@ -218,26 +219,4 @@ func (r *Reconciler) getRealGCPService(namespace string, providerConfig machinev
 		return nil, mapierrors.InvalidMachineConfiguration("error creating compute service: %v", err)
 	}
 	return computeService, nil
-}
-
-// isUEFICompatible will detect if the machine's boot disk was created with a UEFI image.
-// Shielded VMs can only be made with UEFI-compatible images. However, OpenShift images listed on the GCP marketplace
-// are not updated with every release, and the 4.8 image is used until 4.12 and was not created with UEFI support.
-func isUEFICompatible(gceService computeservice.GCPComputeService, providerConfig *machinev1.GCPMachineProviderSpec) (bool, error) {
-	for _, disk := range providerConfig.Disks {
-		if !disk.Boot {
-			continue
-		}
-		img, err := gceService.ImageGet(providerConfig.ProjectID, disk.Image)
-		if err != nil {
-			return false, fmt.Errorf("unable to retrieve image %s in project %s: %s", disk.Image, providerConfig.ProjectID, err)
-		}
-		for _, feat := range img.GuestOsFeatures {
-			if strings.Contains(feat.Type, util.UEFICompatible) {
-				return true, nil
-			}
-		}
-
-	}
-	return false, nil
 }

--- a/pkg/cloud/gcp/actuators/machineset/controller.go
+++ b/pkg/cloud/gcp/actuators/machineset/controller.go
@@ -176,9 +176,10 @@ func (r *Reconciler) reconcile(machineSet *machinev1.MachineSet) (ctrl.Result, e
 		fmt.Sprintf("kubernetes.io/arch=%s", util.CPUArchitecture(providerConfig.MachineType)),
 		machineSet.Annotations[labelsKey])
 
-	// From OCP 4.13, we enable Shielded Instance Config by default. However, in
-	// some cases the boot disk is not UEFI compatible and instance creation will
-	// fail. This may present as customers being unable to scale existing
+	// OCP 4.12 and under did not have the ShieldedInstanceConfig field. From OCP
+	// 4.13, we enable Shielded Instance Config by default. In some cases the
+	// boot disk is not UEFI compatible and instance creation will fail with the
+	// new default. This may present as customers being unable to scale existing
 	// machinesets. We should disable the shielded instance config in the
 	// MachineSet's template, so that new Machines created from it will boot.
 	uefiCompatible, err := util.IsUEFICompatible(gceService, providerConfig)

--- a/pkg/cloud/gcp/actuators/machineset/controller_test.go
+++ b/pkg/cloud/gcp/actuators/machineset/controller_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Reconciler", func() {
 	}
 
 	DescribeTable("when reconciling MachineSets", func(rtc reconcileTestCase) {
-		machineSet, err := newTestMachineSet(namespace.Name, rtc.machineType, rtc.guestAccelerators, rtc.existingAnnotations)
+		machineSet, err := newTestMachineSet(namespace.Name, rtc.machineType, rtc.guestAccelerators, rtc.existingAnnotations, nil)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(c.Create(ctx, machineSet)).To(Succeed())
@@ -420,7 +420,7 @@ func TestReconcile(t *testing.T) {
 				},
 			}
 
-			machineSet, err := newTestMachineSet("default", tc.machineType, tc.guestAccelerators, tc.existingAnnotations)
+			machineSet, err := newTestMachineSet("default", tc.machineType, tc.guestAccelerators, tc.existingAnnotations, nil)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			_, err = r.reconcile(machineSet)
@@ -430,7 +430,64 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-func newTestMachineSet(namespace string, machineType string, guestAccelerators []machinev1.GCPGPUConfig, existingAnnotations map[string]string) (*machinev1.MachineSet, error) {
+func TestReconcileDisks(t *testing.T) {
+	testCases := []struct {
+		name           string
+		disks          []*machinev1.GCPDisk
+		expectDisabled bool
+	}{
+		{
+			name: "boot disk without UEFI",
+			disks: []*machinev1.GCPDisk{
+				{Boot: true},
+			},
+			expectDisabled: true,
+		},
+		{
+			name: "boot disk with UEFI",
+			disks: []*machinev1.GCPDisk{
+				{Boot: true, Image: "uefi"},
+			},
+			expectDisabled: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			g := NewWithT(tt)
+			machineSet, err := newTestMachineSet("default", "n1-standard-2", nil, make(map[string]string), tc.disks)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			_, service := computeservice.NewComputeServiceMock()
+			service.MockMachineTypesGet = mockMachineTypesFunc
+			r := &Reconciler{
+				recorder: record.NewFakeRecorder(1),
+				cache:    newMachineTypesCache(),
+				getGCPService: func(_ string, _ machinev1.GCPMachineProviderSpec) (computeservice.GCPComputeService, error) {
+					return service, nil
+				},
+			}
+
+			_, err = r.reconcile(machineSet)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			providerConfig, err := getproviderConfig(machineSet)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			if tc.expectDisabled {
+				g.Expect(providerConfig.ShieldedInstanceConfig.SecureBoot).To(Equal(machinev1.SecureBootPolicyDisabled))
+				g.Expect(providerConfig.ShieldedInstanceConfig.IntegrityMonitoring).To(Equal(machinev1.IntegrityMonitoringPolicyDisabled))
+				g.Expect(providerConfig.ShieldedInstanceConfig.VirtualizedTrustedPlatformModule).To(Equal(machinev1.VirtualizedTrustedPlatformModulePolicyDisabled))
+			}
+
+			if !tc.expectDisabled {
+				g.Expect(providerConfig.ShieldedInstanceConfig).To(BeEquivalentTo(machinev1.GCPShieldedInstanceConfig{}))
+			}
+
+		})
+	}
+}
+
+func newTestMachineSet(namespace string, machineType string, guestAccelerators []machinev1.GCPGPUConfig, existingAnnotations map[string]string, disks []*machinev1.GCPDisk) (*machinev1.MachineSet, error) {
 	// Copy anntotations map so we don't modify the input
 	annotations := make(map[string]string)
 	for k, v := range existingAnnotations {
@@ -440,6 +497,7 @@ func newTestMachineSet(namespace string, machineType string, guestAccelerators [
 	machineProviderSpec := &machinev1.GCPMachineProviderSpec{
 		MachineType: machineType,
 		GPUs:        guestAccelerators,
+		Disks:       disks,
 	}
 	providerSpec, err := providerSpecFromMachine(machineProviderSpec)
 	if err != nil {

--- a/pkg/cloud/gcp/actuators/machineset/controller_test.go
+++ b/pkg/cloud/gcp/actuators/machineset/controller_test.go
@@ -119,7 +119,14 @@ var _ = Describe("Reconciler", func() {
 	}
 
 	DescribeTable("when reconciling MachineSets", func(rtc reconcileTestCase) {
-		machineSet, err := newTestMachineSet(namespace.Name, rtc.machineType, rtc.guestAccelerators, rtc.existingAnnotations, nil)
+		disks := []*machinev1.GCPDisk{
+			{
+				Boot:  true,
+				Image: "projects/fooproject/global/images/uefi-image",
+			},
+		}
+
+		machineSet, err := newTestMachineSet(namespace.Name, rtc.machineType, rtc.guestAccelerators, rtc.existingAnnotations, disks)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(c.Create(ctx, machineSet)).To(Succeed())
@@ -420,7 +427,14 @@ func TestReconcile(t *testing.T) {
 				},
 			}
 
-			machineSet, err := newTestMachineSet("default", tc.machineType, tc.guestAccelerators, tc.existingAnnotations, nil)
+			disks := []*machinev1.GCPDisk{
+				{
+					Boot:  true,
+					Image: "projects/fooproject/global/images/uefi-image",
+				},
+			}
+
+			machineSet, err := newTestMachineSet("default", tc.machineType, tc.guestAccelerators, tc.existingAnnotations, disks)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			_, err = r.reconcile(machineSet)
@@ -446,7 +460,7 @@ func TestReconcileDisks(t *testing.T) {
 		{
 			name: "boot disk with UEFI",
 			disks: []*machinev1.GCPDisk{
-				{Boot: true, Image: "uefi"},
+				{Boot: true, Image: "uefi-image"},
 			},
 			expectDisabled: false,
 		},

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -28,6 +28,7 @@ type GCPComputeService interface {
 	RegionGet(project string, region string) (*compute.Region, error)
 	GPUCompatibleMachineTypesList(project string, zone string, ctx context.Context) (map[string]int64, []string)
 	AcceleratorTypeGet(project string, zone string, acceleratorType string) (*compute.AcceleratorType, error)
+	ImageGet(project string, image string) (*compute.Image, error)
 	InstanceGroupsListInstances(project string, zone string, instanceGroup string, request *compute.InstanceGroupsListInstancesRequest) (*compute.InstanceGroupsListInstances, error)
 	InstanceGroupsAddInstances(project string, zone string, instance string, instanceGroup string) (*compute.Operation, error)
 	InstanceGroupsRemoveInstances(project string, zone string, instance string, instanceGroup string) (*compute.Operation, error)
@@ -190,4 +191,8 @@ func (c *computeService) AddInstanceGroupToBackendService(project string, region
 
 func (c *computeService) BackendServiceGet(project string, region string, backendServiceName string) (*compute.BackendService, error) {
 	return c.service.RegionBackendServices.Get(project, region, backendServiceName).Do()
+}
+
+func (c *computeService) ImageGet(project string, image string) (*compute.Image, error) {
+	return c.service.Images.Get(project, image).Do()
 }

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -29,6 +29,7 @@ type GCPComputeService interface {
 	GPUCompatibleMachineTypesList(project string, zone string, ctx context.Context) (map[string]int64, []string)
 	AcceleratorTypeGet(project string, zone string, acceleratorType string) (*compute.AcceleratorType, error)
 	ImageGet(project string, image string) (*compute.Image, error)
+	ImageFamilyGet(project string, zone string, family string) (*compute.ImageFamilyView, error)
 	InstanceGroupsListInstances(project string, zone string, instanceGroup string, request *compute.InstanceGroupsListInstancesRequest) (*compute.InstanceGroupsListInstances, error)
 	InstanceGroupsAddInstances(project string, zone string, instance string, instanceGroup string) (*compute.Operation, error)
 	InstanceGroupsRemoveInstances(project string, zone string, instance string, instanceGroup string) (*compute.Operation, error)
@@ -195,4 +196,8 @@ func (c *computeService) BackendServiceGet(project string, region string, backen
 
 func (c *computeService) ImageGet(project string, image string) (*compute.Image, error) {
 	return c.service.Images.Get(project, image).Do()
+}
+
+func (c *computeService) ImageFamilyGet(project string, zone string, family string) (*compute.ImageFamilyView, error) {
+	return c.service.ImageFamilyViews.Get(project, zone, family).Do()
 }

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/util"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
@@ -21,6 +22,7 @@ const (
 	ErrGettingBackendService       = "errGettingBackendService"
 	ErrFailGroupGet                = "errFailGroupGet"
 	ErrGroupNotFound               = "errGroupNotFound"
+	ErrImageNotFound               = "errImageNotFound"
 	PatchBackendService            = "patchBackendService"
 	AddGroupSuccessfully           = "addGroupSuccessfully"
 )
@@ -246,4 +248,20 @@ func (c *GCPComputeServiceMock) BackendServiceGet(project string, region string,
 			},
 		},
 	}, nil
+}
+
+func (c *GCPComputeServiceMock) ImageGet(project string, image string) (*compute.Image, error) {
+	if project == ErrImageNotFound {
+		return nil, errors.New("imageGet request failed")
+	}
+
+	img := &compute.Image{
+		GuestOsFeatures: make([]*compute.GuestOsFeature, 0),
+	}
+
+	if image == "uefi" {
+		img.GuestOsFeatures = append(img.GuestOsFeatures, &compute.GuestOsFeature{Type: util.UEFICompatible})
+	}
+
+	return img, nil
 }

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/util"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
@@ -25,6 +24,7 @@ const (
 	ErrImageNotFound               = "errImageNotFound"
 	PatchBackendService            = "patchBackendService"
 	AddGroupSuccessfully           = "addGroupSuccessfully"
+	UEFICompatible                 = "UEFI_COMPATIBLE"
 )
 
 type GCPComputeServiceMock struct {
@@ -259,9 +259,27 @@ func (c *GCPComputeServiceMock) ImageGet(project string, image string) (*compute
 		GuestOsFeatures: make([]*compute.GuestOsFeature, 0),
 	}
 
-	if image == "uefi" {
-		img.GuestOsFeatures = append(img.GuestOsFeatures, &compute.GuestOsFeature{Type: util.UEFICompatible})
+	if image == "uefi-image" {
+		img.GuestOsFeatures = append(img.GuestOsFeatures, &compute.GuestOsFeature{Type: UEFICompatible})
 	}
 
 	return img, nil
+}
+
+func (c *GCPComputeServiceMock) ImageFamilyGet(project, zone, family string) (*compute.ImageFamilyView, error) {
+	if project == ErrImageNotFound {
+		return nil, errors.New("imageGet request failed")
+	}
+
+	imgView := &compute.ImageFamilyView{
+		Image: &compute.Image{
+			GuestOsFeatures: make([]*compute.GuestOsFeature, 0),
+		},
+	}
+
+	if family == "uefi-image-family" {
+		imgView.Image.GuestOsFeatures = append(imgView.Image.GuestOsFeatures, &compute.GuestOsFeature{Type: UEFICompatible})
+	}
+
+	return imgView, nil
 }

--- a/pkg/cloud/gcp/actuators/util/gcp_uefi_disk_check.go
+++ b/pkg/cloud/gcp/actuators/util/gcp_uefi_disk_check.go
@@ -1,0 +1,127 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	machinev1 "github.com/openshift/api/machine/v1beta1"
+	computeservice "github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/services/compute"
+)
+
+const (
+	UEFICompatible = "UEFI_COMPATIBLE"
+)
+
+// IsUEFICompatible detects if the machine's boot disk was created with a UEFI image.
+// Shielded VMs require UEFI-compatible images. In some instances customers may still
+// be using non UEFI-compatible images. e.g OpenShift images listed on the GCP marketplace
+// are not updated with every release, and the 4.8 image is used until 4.12 and was not
+// created with UEFI support.
+func IsUEFICompatible(gceService computeservice.GCPComputeService, providerConfig *machinev1.GCPMachineProviderSpec) (bool, error) {
+	for _, disk := range providerConfig.Disks {
+		if !disk.Boot {
+			continue
+		}
+
+		// Parse the image reference from the disk.
+		imageRef, err := parseImageReference(disk.Image, providerConfig.ProjectID)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse disk image reference: %w", err)
+		}
+
+		if imageRef.IsFamily {
+			return checkImageFamilyImageUEFICompatible(gceService, imageRef.Project, providerConfig.Zone, imageRef.Image)
+		}
+		return checkImageUEFICompatible(gceService, imageRef.Project, imageRef.Image)
+	}
+	return false, fmt.Errorf("no boot disk found")
+}
+
+// imageReference holds parsed details from a disk.Image string.
+type imageReference struct {
+	Project  string
+	Image    string
+	IsFamily bool // true if the image is specified as a family reference.
+}
+
+// parseImageReference extracts project and image information from the given image string.
+// It supports various formats:
+//   - "projects/{project}/global/images/{image}"
+//   - "projects/{project}/global/images/family/{imageFamily}"
+//   - A simple image name without slashes, in which case providerProject is used.
+func parseImageReference(imageStr, providerProject string) (*imageReference, error) {
+	// If the image string does not contain a slash, assume it's a simple image name.
+	if !strings.Contains(imageStr, "/") {
+		return &imageReference{
+			Project:  providerProject,
+			Image:    imageStr,
+			IsFamily: false,
+		}, nil
+	}
+
+	// Check if the image string contains "projects/".
+	if !strings.Contains(imageStr, "projects/") {
+		return nil, fmt.Errorf("image string %q does not contain expected 'projects/' segment", imageStr)
+	}
+
+	// Split based on "projects/".
+	parts := strings.SplitN(imageStr, "projects/", 2)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("unexpected format for image string: %q", imageStr)
+	}
+
+	// Split the remainder by "/".
+	subParts := strings.Split(parts[1], "/")
+	// Expected formats:
+	// For non-family images: {project}/global/images/{image} => at least 4 parts.
+	// For family images: {project}/global/images/family/{imageFamily} => at least 5 parts.
+	if len(subParts) < 4 {
+		return nil, fmt.Errorf("unexpected image path format in %q", imageStr)
+	}
+
+	// Determine if the image is specified as a family.
+	isFamily := false
+	imageName := ""
+	if len(subParts) >= 5 && subParts[2] == "images" && subParts[3] == "family" {
+		isFamily = true
+		imageName = subParts[4]
+	} else if subParts[1] == "global" && subParts[2] == "images" {
+		imageName = subParts[3]
+	} else {
+		return nil, fmt.Errorf("unrecognized image path format in %q", imageStr)
+	}
+
+	return &imageReference{
+		Project:  subParts[0],
+		Image:    imageName,
+		IsFamily: isFamily,
+	}, nil
+}
+
+// checkImageUEFICompatible retrieves the image and checks its GuestOSFeatures for UEFI support.
+func checkImageUEFICompatible(gceService computeservice.GCPComputeService, project, image string) (bool, error) {
+	img, err := gceService.ImageGet(project, image)
+	if err != nil {
+		return false, fmt.Errorf("unable to retrieve image %q in project %q: %w", image, project, err)
+	}
+	for _, feat := range img.GuestOsFeatures {
+		if strings.EqualFold(feat.Type, UEFICompatible) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// checkImageFamilyImageUEFICompatible retrieves the image family and checks for UEFI support.
+func checkImageFamilyImageUEFICompatible(gceService computeservice.GCPComputeService, project, zone, imageFamily string) (bool, error) {
+	family, err := gceService.ImageFamilyGet(project, zone, imageFamily)
+	if err != nil {
+		return false, fmt.Errorf("unable to retrieve image family %q in project %q: %w", imageFamily, project, err)
+	}
+	for _, feat := range family.Image.GuestOsFeatures {
+		if strings.EqualFold(feat.Type, UEFICompatible) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/cloud/gcp/actuators/util/gcp_uefi_disk_check.go
+++ b/pkg/cloud/gcp/actuators/util/gcp_uefi_disk_check.go
@@ -48,6 +48,7 @@ type imageReference struct {
 // It supports various formats:
 //   - "projects/{project}/global/images/{image}"
 //   - "projects/{project}/global/images/family/{imageFamily}"
+//   - "https://www.googleapis.com/compute/v1/projects/{project}/global/images/{image}"
 //   - A simple image name without slashes, in which case providerProject is used.
 func parseImageReference(imageStr, providerProject string) (*imageReference, error) {
 	// If the image string does not contain a slash, assume it's a simple image name.

--- a/pkg/cloud/gcp/actuators/util/gcp_uefi_disk_check_test.go
+++ b/pkg/cloud/gcp/actuators/util/gcp_uefi_disk_check_test.go
@@ -1,0 +1,196 @@
+package util_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	machinev1 "github.com/openshift/api/machine/v1beta1"
+	machinev1builder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1"
+	computeservice "github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/services/compute"
+	"github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/util"
+)
+
+var _ = Describe("IsUEFICompatible", func() {
+
+	type standardImageInput struct {
+		boot                 bool
+		compatible           bool
+		disks                []*machinev1.GCPDisk
+		expectedErrSubstring string
+		image                string
+		projectID            string
+		zone                 string
+	}
+
+	var tableFunc func(in standardImageInput) = func(in standardImageInput) {
+		_, computeService := computeservice.NewComputeServiceMock()
+		providerSpecBuilder := machinev1builder.GCPProviderSpec()
+
+		if len(in.disks) != 0 {
+			providerSpecBuilder = providerSpecBuilder.WithDisks(in.disks)
+		} else {
+			providerSpecBuilder = providerSpecBuilder.WithDisks([]*machinev1.GCPDisk{
+				{
+					Boot:  in.boot,
+					Image: in.image,
+				},
+			})
+		}
+
+		if in.projectID != "" {
+			providerSpecBuilder = providerSpecBuilder.WithProjectID(in.projectID)
+		}
+
+		if in.zone != "" {
+			providerSpecBuilder = providerSpecBuilder.WithZone(in.zone)
+		}
+
+		providerSpec := providerSpecBuilder.Build()
+
+		compatible, err := util.IsUEFICompatible(computeService, providerSpec)
+		if in.expectedErrSubstring != "" {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(in.expectedErrSubstring))
+		} else {
+			Expect(err).ToNot(HaveOccurred())
+		}
+		Expect(compatible).To(Equal(in.compatible))
+	}
+
+	DescribeTable("Standard image references in format projects/{project}/global/images/{image}",
+		tableFunc,
+		Entry("UEFI compatible image", standardImageInput{
+			boot:       true,
+			image:      "projects/fooproject/global/images/uefi-image",
+			compatible: true,
+		}),
+		Entry("Non-UEFI image", standardImageInput{
+			boot:       true,
+			image:      "projects/fooproject/global/images/fooimage",
+			compatible: false,
+		}),
+		Entry("Image not found", standardImageInput{
+			boot:                 true,
+			image:                "projects/errImageNotFound/global/images/fooimage",
+			expectedErrSubstring: "unable to retrieve image",
+			compatible:           false,
+		}),
+		Entry("Malformed image reference", standardImageInput{
+			boot:                 true,
+			image:                "projects/errImageNotFound//asdf/images456/fooimage",
+			expectedErrSubstring: "unrecognized image path format",
+			compatible:           false,
+		}),
+	)
+
+	DescribeTable("Simple image names",
+		tableFunc,
+		Entry("Simple UEFI compatible image", standardImageInput{
+			boot:       true,
+			image:      "uefi-image",
+			projectID:  "simple-project",
+			compatible: true,
+		}),
+		Entry("Simple non-UEFI image", standardImageInput{
+			boot:       true,
+			image:      "non-uefi",
+			projectID:  "simple-project",
+			compatible: false,
+		}),
+		Entry("Simple image not found", standardImageInput{
+			boot:                 true,
+			image:                "nonexistent",
+			projectID:            "errImageNotFound",
+			expectedErrSubstring: "unable to retrieve image",
+			compatible:           false,
+		}),
+	)
+
+	DescribeTable("Family image references in format projects/{project}/global/images/family/{imageFamily}",
+		tableFunc,
+		Entry("UEFI compatible image family", standardImageInput{
+			boot:       true,
+			image:      "projects/fooproject/global/images/family/uefi-image-family",
+			zone:       "us-central1-a",
+			compatible: true,
+		}),
+		Entry("Non-UEFI image family", standardImageInput{
+			boot:       true,
+			image:      "projects/fooproject/global/images/family/fooimage",
+			zone:       "us-central1-a",
+			compatible: false,
+		}),
+		Entry("Image family not found", standardImageInput{
+			boot:                 true,
+			image:                "projects/errImageNotFound/global/images/family/fooimage",
+			zone:                 "us-central1-a",
+			expectedErrSubstring: "unable to retrieve image family",
+			compatible:           false,
+		}),
+	)
+
+	DescribeTable("FQDN image URLs",
+		tableFunc,
+		Entry("UEFI compatible FQDN image", standardImageInput{
+			boot:       true,
+			image:      "https://www.googleapis.com/compute/v1/projects/fooproject/global/images/uefi-image",
+			compatible: true,
+		}),
+		Entry("Non-UEFI FQDN image", standardImageInput{
+			boot:       true,
+			image:      "https://www.googleapis.com/compute/v1/projects/fooproject/global/images/fooimage",
+			compatible: false,
+		}),
+		Entry("FQDN URL missing 'projects/' segment", standardImageInput{
+			boot:                 true,
+			image:                "https://www.googleapis.com/compute/v1/global/images/uefi-image",
+			expectedErrSubstring: "does not contain expected 'projects/'",
+			compatible:           false,
+		}),
+		Entry("FQDN URL with incomplete segments", standardImageInput{
+			boot:                 true,
+			image:                "https://www.googleapis.com/compute/v1/projects/fooproject/global/images",
+			expectedErrSubstring: "unexpected image path format",
+			compatible:           false,
+		}),
+		Entry("FQDN URL not following recognized pattern", standardImageInput{
+			boot:                 true,
+			image:                "https://www.googleapis.com/compute/v1/projects/fooproject/global/foo/uefi-image",
+			expectedErrSubstring: "unrecognized image path format",
+			compatible:           false,
+		}),
+	)
+
+	DescribeTable("Disks are not standard",
+		tableFunc,
+		Entry("When no boot disk is found", standardImageInput{
+			compatible: false,
+			disks: []*machinev1.GCPDisk{
+				{
+					Boot:  false,
+					Image: "projects/fooproject/global/images/uefi-image",
+				},
+				{
+					Boot:  false,
+					Image: "projects/fooproject/global/images/fooimage",
+				},
+			},
+			expectedErrSubstring: "no boot disk found",
+		}),
+		Entry("When the boot disk is not the first disk in the list", standardImageInput{
+			compatible: true,
+			disks: []*machinev1.GCPDisk{
+				{
+					Boot:  false,
+					Image: "non-uefi-simple",
+				},
+				{
+					Boot:  true,
+					Image: "uefi-image",
+				},
+			},
+			projectID: "simple-project",
+		}),
+	)
+
+})

--- a/pkg/cloud/gcp/actuators/util/register.go
+++ b/pkg/cloud/gcp/actuators/util/register.go
@@ -10,10 +10,6 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const (
-	UEFICompatible = "UEFI_COMPATIBLE"
-)
-
 // RawExtensionFromProviderSpec marshals the machine provider spec.
 func RawExtensionFromProviderSpec(spec *machinev1.GCPMachineProviderSpec) (*runtime.RawExtension, error) {
 	if spec == nil {

--- a/pkg/cloud/gcp/actuators/util/register.go
+++ b/pkg/cloud/gcp/actuators/util/register.go
@@ -10,6 +10,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	UEFICompatible = "UEFI_COMPATIBLE"
+)
+
 // RawExtensionFromProviderSpec marshals the machine provider spec.
 func RawExtensionFromProviderSpec(spec *machinev1.GCPMachineProviderSpec) (*runtime.RawExtension, error) {
 	if spec == nil {

--- a/pkg/cloud/gcp/actuators/util/util_suite_test.go
+++ b/pkg/cloud/gcp/actuators/util/util_suite_test.go
@@ -1,0 +1,13 @@
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/LICENSE
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1/cluster_operator.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1/cluster_operator.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ClusterOperator creates a new cluster operator builder.
+func ClusterOperator() ClusterOperatorBuilder {
+	return ClusterOperatorBuilder{}
+}
+
+// ClusterOperatorBuilder is used to build out a cluster operator object.
+type ClusterOperatorBuilder struct {
+	name string
+}
+
+// Build builds a new cluster operator based on the configuration provided.
+func (n ClusterOperatorBuilder) Build() *configv1.ClusterOperator {
+	return &configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: n.name,
+		},
+	}
+}
+
+// WithName sets the name for the cluster operator builder.
+func (n ClusterOperatorBuilder) WithName(name string) ClusterOperatorBuilder {
+	n.name = name
+	return n
+}
+
+// ClusterOperatorStatus creates a new cluster operator status builder.
+func ClusterOperatorStatus() ClusterOperatorStatusBuilder {
+	return ClusterOperatorStatusBuilder{}
+}
+
+// ClusterOperatorStatusBuilder is used to build out a cluster operator status object.
+type ClusterOperatorStatusBuilder struct {
+	conditions []configv1.ClusterOperatorStatusCondition
+}
+
+// Build builds a new cluster operator status based on the configuration provided.
+func (n ClusterOperatorStatusBuilder) Build() configv1.ClusterOperatorStatus {
+	return configv1.ClusterOperatorStatus{
+		Conditions: n.conditions,
+	}
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1/infrastructure.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1/infrastructure.go
@@ -1,0 +1,384 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+// Infrastructure creates a new infrastructure builder.
+func Infrastructure() InfrastructureBuilder {
+	return InfrastructureBuilder{
+		name: "cluster",
+	}
+}
+
+// InfrastructureBuilder is used to build out an infrastructure object.
+type InfrastructureBuilder struct {
+	generateName string
+	name         string
+	namespace    string
+	labels       map[string]string
+	spec         *configv1.InfrastructureSpec
+	status       *configv1.InfrastructureStatus
+}
+
+// Build builds a new infrastructure object based on the configuration provided.
+func (i InfrastructureBuilder) Build() *configv1.Infrastructure {
+	infra := &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: i.generateName,
+			Name:         i.name,
+			Namespace:    i.namespace,
+			Labels:       i.labels,
+		},
+	}
+
+	if i.spec != nil {
+		infra.Spec = *i.spec
+	}
+
+	if i.status != nil {
+		infra.Status = *i.status
+	}
+
+	return infra
+}
+
+// AsAWS sets the Status for the infrastructure builder.
+func (i InfrastructureBuilder) AsAWS(name string, region string) InfrastructureBuilder {
+	i.spec = &configv1.InfrastructureSpec{
+		PlatformSpec: configv1.PlatformSpec{
+			Type: "AWS",
+			AWS:  &configv1.AWSPlatformSpec{},
+		},
+	}
+	i.status = &configv1.InfrastructureStatus{
+		InfrastructureName:     name,
+		APIServerURL:           "https://api.test-cluster.test-domain:6443",
+		APIServerInternalURL:   "https://api-int.test-cluster.test-domain:6443",
+		EtcdDiscoveryDomain:    "",
+		ControlPlaneTopology:   configv1.HighlyAvailableTopologyMode,
+		InfrastructureTopology: configv1.HighlyAvailableTopologyMode,
+		PlatformStatus: &configv1.PlatformStatus{
+			Type: "AWS",
+			AWS: &configv1.AWSPlatformStatus{
+				Region: region,
+			},
+		},
+	}
+
+	return i
+}
+
+// AsAzure sets the Status for the infrastructure builder.
+func (i InfrastructureBuilder) AsAzure(name string) InfrastructureBuilder {
+	i.spec = &configv1.InfrastructureSpec{
+		PlatformSpec: configv1.PlatformSpec{
+			Type:  "Azure",
+			Azure: &configv1.AzurePlatformSpec{},
+		},
+	}
+	i.status = &configv1.InfrastructureStatus{
+		InfrastructureName:     name,
+		APIServerURL:           "https://api.test-cluster.test-domain:6443",
+		APIServerInternalURL:   "https://api-int.test-cluster.test-domain:6443",
+		EtcdDiscoveryDomain:    "",
+		ControlPlaneTopology:   configv1.HighlyAvailableTopologyMode,
+		InfrastructureTopology: configv1.HighlyAvailableTopologyMode,
+		PlatformStatus: &configv1.PlatformStatus{
+			Type:  "Azure",
+			Azure: &configv1.AzurePlatformStatus{},
+		},
+	}
+
+	return i
+}
+
+// AsGCP sets the Status for the infrastructure builder.
+func (i InfrastructureBuilder) AsGCP(name string, region string) InfrastructureBuilder {
+	i.spec = &configv1.InfrastructureSpec{
+		PlatformSpec: configv1.PlatformSpec{
+			Type: configv1.GCPPlatformType,
+			GCP:  &configv1.GCPPlatformSpec{},
+		},
+	}
+	i.status = &configv1.InfrastructureStatus{
+		InfrastructureName:     name,
+		APIServerURL:           "https://api.test-cluster.test-domain:6443",
+		APIServerInternalURL:   "https://api-int.test-cluster.test-domain:6443",
+		EtcdDiscoveryDomain:    "",
+		ControlPlaneTopology:   configv1.HighlyAvailableTopologyMode,
+		InfrastructureTopology: configv1.HighlyAvailableTopologyMode,
+		PlatformStatus: &configv1.PlatformStatus{
+			Type: configv1.GCPPlatformType,
+			GCP: &configv1.GCPPlatformStatus{
+				Region: region,
+			},
+		},
+	}
+
+	return i
+}
+
+// AsOpenStack sets the Status for the infrastructure builder.
+func (i InfrastructureBuilder) AsOpenStack(name string) InfrastructureBuilder {
+	i.spec = &configv1.InfrastructureSpec{
+		PlatformSpec: configv1.PlatformSpec{
+			Type:      configv1.OpenStackPlatformType,
+			OpenStack: &configv1.OpenStackPlatformSpec{},
+		},
+	}
+	i.status = &configv1.InfrastructureStatus{
+		InfrastructureName:     name,
+		APIServerURL:           "https://api.test-cluster.test-domain:6443",
+		APIServerInternalURL:   "https://api-int.test-cluster.test-domain:6443",
+		EtcdDiscoveryDomain:    "",
+		ControlPlaneTopology:   configv1.HighlyAvailableTopologyMode,
+		InfrastructureTopology: configv1.HighlyAvailableTopologyMode,
+		PlatformStatus: &configv1.PlatformStatus{
+			Type: configv1.OpenStackPlatformType,
+			OpenStack: &configv1.OpenStackPlatformStatus{
+				APIServerInternalIPs: []string{"10.0.0.5"},
+				IngressIPs:           []string{"10.0.0.7"},
+			},
+		},
+	}
+
+	return i
+}
+
+// AsNutanix sets the Status for the infrastructure builder.
+func (i InfrastructureBuilder) AsNutanix(name string) InfrastructureBuilder {
+	i.spec = &configv1.InfrastructureSpec{
+		PlatformSpec: configv1.PlatformSpec{
+			Type: configv1.NutanixPlatformType,
+			Nutanix: &configv1.NutanixPlatformSpec{
+				PrismCentral: configv1.NutanixPrismEndpoint{
+					Address: "https://pc0_address",
+					Port:    9440,
+				},
+				PrismElements: []configv1.NutanixPrismElementEndpoint{
+					{
+						Name: "pe0",
+						Endpoint: configv1.NutanixPrismEndpoint{
+							Address: "pe0-address",
+							Port:    9440,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	i.status = &configv1.InfrastructureStatus{
+		InfrastructureName:     name,
+		APIServerURL:           "https://api.test-cluster.test-domain:6443",
+		APIServerInternalURL:   "https://api-int.test-cluster.test-domain:6443",
+		EtcdDiscoveryDomain:    "",
+		ControlPlaneTopology:   configv1.HighlyAvailableTopologyMode,
+		InfrastructureTopology: configv1.HighlyAvailableTopologyMode,
+		PlatformStatus: &configv1.PlatformStatus{
+			Type: configv1.NutanixPlatformType,
+			Nutanix: &configv1.NutanixPlatformStatus{
+				APIServerInternalIPs: []string{"10.0.0.5"},
+				IngressIPs:           []string{"10.0.0.7"},
+			},
+		},
+	}
+
+	return i
+}
+
+// AsNutanixWithFailureDomains returns a Nutanix infrastructure resource with failure domains.
+// if failureDomains is nil, default failure domains will be applied to the resource which are
+// compatible with machinev1beta1resourcebuilder default failure domain names.
+func (i InfrastructureBuilder) AsNutanixWithFailureDomains(name string, failureDomains *[]configv1.NutanixFailureDomain) InfrastructureBuilder {
+	infraBuilder := i.AsNutanix(name)
+
+	if failureDomains != nil {
+		infraBuilder.spec.PlatformSpec.Nutanix.FailureDomains = *failureDomains
+	} else {
+		infraBuilder.spec.PlatformSpec.Nutanix.FailureDomains = []configv1.NutanixFailureDomain{
+			{
+				Name: "fd-pe0",
+				Cluster: configv1.NutanixResourceIdentifier{
+					Type: configv1.NutanixIdentifierName,
+					Name: ptr.To[string]("pe0"),
+				},
+				Subnets: []configv1.NutanixResourceIdentifier{{
+					Type: configv1.NutanixIdentifierName,
+					Name: ptr.To[string]("pe0-subnet"),
+				}},
+			},
+			{
+				Name: "fd-pe1",
+				Cluster: configv1.NutanixResourceIdentifier{
+					Type: configv1.NutanixIdentifierUUID,
+					UUID: ptr.To[string]("0005a0f3-8f43-a0f5-02b7-3cecef194315"),
+				},
+				Subnets: []configv1.NutanixResourceIdentifier{{
+					Type: configv1.NutanixIdentifierName,
+					Name: ptr.To[string]("pe1-subnet"),
+				}},
+			},
+			{
+				Name: "fd-pe2",
+				Cluster: configv1.NutanixResourceIdentifier{
+					Type: configv1.NutanixIdentifierName,
+					Name: ptr.To[string]("pe2"),
+				},
+				Subnets: []configv1.NutanixResourceIdentifier{{
+					Type: configv1.NutanixIdentifierUUID,
+					UUID: ptr.To[string]("a8938dc6-7659-6801-a688-e26020c68241"),
+				}},
+			},
+		}
+	}
+
+	i.spec = infraBuilder.spec
+	i.status = infraBuilder.status
+
+	return i
+}
+
+// AsVSphere sets the Status for the infrastructure builder.
+func (i InfrastructureBuilder) AsVSphere(name string) InfrastructureBuilder {
+	i.spec = &configv1.InfrastructureSpec{
+		PlatformSpec: configv1.PlatformSpec{
+			Type:    configv1.VSpherePlatformType,
+			VSphere: &configv1.VSpherePlatformSpec{},
+		},
+	}
+	i.status = &configv1.InfrastructureStatus{
+		InfrastructureName:     name,
+		APIServerURL:           "https://api.test-cluster.test-domain:6443",
+		APIServerInternalURL:   "https://api-int.test-cluster.test-domain:6443",
+		EtcdDiscoveryDomain:    "",
+		ControlPlaneTopology:   configv1.HighlyAvailableTopologyMode,
+		InfrastructureTopology: configv1.HighlyAvailableTopologyMode,
+		PlatformStatus: &configv1.PlatformStatus{
+			Type: configv1.VSpherePlatformType,
+			VSphere: &configv1.VSpherePlatformStatus{
+				APIServerInternalIPs: []string{"10.0.0.5"},
+				IngressIPs:           []string{"10.0.0.7"},
+			},
+		},
+	}
+
+	return i
+}
+
+// AsVSphereWithFailureDomains returns a VSphere infrastructure resource with failure domains.
+// if failureDomains = nil, default failure domains will be applied to the resource which are
+// compatible with machinev1beta1resourcebuilder default failure domain names.
+func (i InfrastructureBuilder) AsVSphereWithFailureDomains(name string, failureDomains *[]configv1.VSpherePlatformFailureDomainSpec) InfrastructureBuilder {
+	infraBuilder := i.AsVSphere(name)
+	if failureDomains != nil {
+		infraBuilder.spec.PlatformSpec.VSphere.FailureDomains = *failureDomains
+	} else {
+		infraBuilder.spec.PlatformSpec.VSphere.FailureDomains = []configv1.VSpherePlatformFailureDomainSpec{
+			{
+				Name:   "us-central1-a",
+				Region: "us-central",
+				Zone:   "1-a",
+				Server: "vcenter.test.com",
+				Topology: configv1.VSpherePlatformTopology{
+					Datacenter:     "test-dc1",
+					ComputeCluster: "/test-dc1/host/test-cluster-1",
+					Networks: []string{
+						"test-network-1",
+					},
+					Datastore:    "/test-dc1/datastore/test-datastore-1",
+					ResourcePool: "/test-dc1/host/test-cluster-1/Resources",
+				},
+			},
+			{
+				Name:   "us-central1-b",
+				Region: "us-central",
+				Zone:   "1-b",
+				Server: "vcenter.test.com",
+				Topology: configv1.VSpherePlatformTopology{
+					Datacenter:     "test-dc2",
+					ComputeCluster: "/test-dc2/host/test-cluster-2",
+					Networks: []string{
+						"test-network-2",
+					},
+					Datastore:    "/test-dc2/datastore/test-datastore-2",
+					ResourcePool: "/test-dc2/host/test-cluster-2/Resources",
+				},
+			},
+			{
+				Name:   "us-central1-c",
+				Region: "us-central",
+				Zone:   "1-c",
+				Server: "vcenter.test.com",
+				Topology: configv1.VSpherePlatformTopology{
+					Datacenter:     "test-dc3",
+					ComputeCluster: "/test-dc3/host/test-cluster-3",
+					Networks: []string{
+						"test-network-3",
+					},
+					Datastore:    "/test-dc3/datastore/test-datastore-3",
+					ResourcePool: "/test-dc3/host/test-cluster-3/Resources",
+				},
+			},
+		}
+	}
+
+	i.spec = infraBuilder.spec
+	i.status = infraBuilder.status
+
+	return i
+}
+
+// WithGenerateName sets the generateName for the infrastructure builder.
+func (i InfrastructureBuilder) WithGenerateName(generateName string) InfrastructureBuilder {
+	i.generateName = generateName
+	return i
+}
+
+// WithLabel sets the labels for the infrastructure builder.
+func (i InfrastructureBuilder) WithLabel(key, value string) InfrastructureBuilder {
+	if i.labels == nil {
+		i.labels = make(map[string]string)
+	}
+
+	i.labels[key] = value
+
+	return i
+}
+
+// WithLabels sets the labels for the infrastructure builder.
+func (i InfrastructureBuilder) WithLabels(labels map[string]string) InfrastructureBuilder {
+	i.labels = labels
+	return i
+}
+
+// WithName sets the name for the infrastructure builder.
+func (i InfrastructureBuilder) WithName(name string) InfrastructureBuilder {
+	i.name = name
+	return i
+}
+
+// WithNamespace sets the namespace for the infrastructure builder.
+func (i InfrastructureBuilder) WithNamespace(namespace string) InfrastructureBuilder {
+	i.namespace = namespace
+	return i
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/consts.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/consts.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebuilder
+
+const (
+	// OpenshiftMachineAPINamespaceName is the name of the OpenShift
+	// Machine API namespace.
+	OpenshiftMachineAPINamespaceName = "openshift-machine-api"
+
+	// TestClusterIDValue is the clusterID in the test environment.
+	TestClusterIDValue = "cluster-test-id"
+
+	// MachineRoleLabelName is the name for the machine role label.
+	MachineRoleLabelName = "machine.openshift.io/cluster-api-machine-role"
+
+	// MachineTypeLabelName is the name for the machine type label.
+	MachineTypeLabelName = "machine.openshift.io/cluster-api-machine-type"
+)

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/interfaces.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/interfaces.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebuilder
+
+import (
+	machinev1 "github.com/openshift/api/machine/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ControlPlaneMachineSetTemplateBuilder builds a ControlPlaneMachineSetTemplate.
+// This is used to create templates for embedding within a ControlPlaneMachineSet.
+type ControlPlaneMachineSetTemplateBuilder interface {
+	BuildTemplate() machinev1.ControlPlaneMachineSetTemplate
+}
+
+// OpenShiftMachineV1Beta1FailureDomainsBuilder builds a FailureDomains.
+// This is used for setting the failure domains in the OpenShift machine template.
+type OpenShiftMachineV1Beta1FailureDomainsBuilder interface {
+	BuildFailureDomains() machinev1.FailureDomains
+}
+
+// RawExtensionBuilder builds a raw extension.
+// This is used to create generic provider specs for embedding within Machines.
+type RawExtensionBuilder interface {
+	BuildRawExtension() *runtime.RawExtension
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/aws_provider_spec.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/aws_provider_spec.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"encoding/json"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+)
+
+// AWSProviderSpec creates a new AWS machine config builder.
+func AWSProviderSpec() AWSProviderSpecBuilder {
+	return AWSProviderSpecBuilder{
+		availabilityZone: "us-east-1a",
+		instanceType:     "m6i.xlarge",
+		securityGroups: []machinev1beta1.AWSResourceReference{
+			{
+				Filters: []machinev1beta1.Filter{
+					{
+						Name: "tag:Name",
+						Values: []string{
+							"aws-security-group-12345678",
+						},
+					},
+				},
+			},
+		},
+		subnet: machinev1beta1.AWSResourceReference{
+			Filters: []machinev1beta1.Filter{
+				{
+					Name: "tag:Name",
+					Values: []string{
+						"aws-subnet-12345678",
+					},
+				},
+			},
+		},
+	}
+}
+
+// AWSProviderSpecBuilder is used to build out a AWS machine config object.
+type AWSProviderSpecBuilder struct {
+	availabilityZone string
+	instanceType     string
+	securityGroups   []machinev1beta1.AWSResourceReference
+	subnet           machinev1beta1.AWSResourceReference
+}
+
+// Build builds a new AWS machine config based on the configuration provided.
+func (m AWSProviderSpecBuilder) Build() *machinev1beta1.AWSMachineProviderConfig {
+	return &machinev1beta1.AWSMachineProviderConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "awsproviderconfig.openshift.io/v1beta1",
+			Kind:       "AWSMachineProviderConfig",
+		},
+		AMI: machinev1beta1.AWSResourceReference{
+			ID: ptr.To[string]("aws-ami-12345678"),
+		},
+		BlockDevices: []machinev1beta1.BlockDeviceMappingSpec{
+			{
+				EBS: &machinev1beta1.EBSBlockDeviceSpec{
+					Encrypted:  ptr.To[bool](true),
+					VolumeSize: ptr.To[int64](120),
+					VolumeType: ptr.To[string]("gp3"),
+				},
+			},
+		},
+		CredentialsSecret: &corev1.LocalObjectReference{
+			Name: "aws-cloud-credentials",
+		},
+		IAMInstanceProfile: &machinev1beta1.AWSResourceReference{
+			ID: ptr.To[string]("aws-iam-instance-profile-12345678"),
+		},
+		InstanceType: m.instanceType,
+		LoadBalancers: []machinev1beta1.LoadBalancerReference{
+			{
+				Type: "network",
+				Name: "aws-nlb-int",
+			},
+			{
+				Type: "network",
+				Name: "aws-nlb-ext",
+			},
+		},
+		Placement: machinev1beta1.Placement{
+			Region:           "us-east-1",
+			AvailabilityZone: m.availabilityZone,
+		},
+		SecurityGroups: m.securityGroups,
+		Subnet:         m.subnet,
+		UserDataSecret: &corev1.LocalObjectReference{
+			Name: "aws-user-data-12345678",
+		},
+	}
+}
+
+// BuildRawExtension builds a new AWS machine config based on the configuration provided.
+func (m AWSProviderSpecBuilder) BuildRawExtension() *runtime.RawExtension {
+	providerConfig := m.Build()
+
+	raw, err := json.Marshal(providerConfig)
+	if err != nil {
+		// As we are building the input to json.Marshal, this should never happen.
+		panic(err)
+	}
+
+	return &runtime.RawExtension{
+		Raw: raw,
+	}
+}
+
+// WithAvailabilityZone sets the availabilityZone for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithAvailabilityZone(az string) AWSProviderSpecBuilder {
+	m.availabilityZone = az
+	return m
+}
+
+// WithInstanceType sets the instanceType for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithInstanceType(instanceType string) AWSProviderSpecBuilder {
+	m.instanceType = instanceType
+	return m
+}
+
+// WithSecurityGroups sets the securityGroups for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithSecurityGroups(sgs []machinev1beta1.AWSResourceReference) AWSProviderSpecBuilder {
+	m.securityGroups = sgs
+	return m
+}
+
+// WithSubnet sets the subnet for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithSubnet(subnet machinev1beta1.AWSResourceReference) AWSProviderSpecBuilder {
+	m.subnet = subnet
+	return m
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/azure_provider_spec.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/azure_provider_spec.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"encoding/json"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// AzureProviderSpec creates a new Azure machine config builder.
+func AzureProviderSpec() AzureProviderSpecBuilder {
+	return AzureProviderSpecBuilder{
+		internalLoadBalancer: "internal-load-balancer-12345678",
+		vmSize:               "Standard_D4s_v3",
+		zone:                 "1",
+		subnet:               "cluster-subnet-12345678",
+	}
+}
+
+// AzureProviderSpecBuilder is used to build a Azure machine config object.
+type AzureProviderSpecBuilder struct {
+	internalLoadBalancer string
+	vmSize               string
+	zone                 string
+	subnet               string
+}
+
+// Build builds a new Azure machine config based on the configuration provided.
+func (m AzureProviderSpecBuilder) Build() *machinev1beta1.AzureMachineProviderSpec {
+	return &machinev1beta1.AzureMachineProviderSpec{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machine.openshift.io/v1beta1",
+			Kind:       "AzureMachineProviderSpec",
+		},
+		UserDataSecret: &v1.SecretReference{
+			Name: "worker-user-data",
+		},
+		CredentialsSecret: &v1.SecretReference{
+			Name:      "azure-cloud-credentials",
+			Namespace: "openshift-machine-api",
+		},
+		Location: "test-location",
+		Vnet:     "vnet-12345678",
+		VMSize:   m.vmSize,
+		Image: machinev1beta1.Image{
+			ResourceID: "/resourceGroups/test-rg/providers/Microsoft.Compute/images/test-image",
+		},
+		OSDisk: machinev1beta1.OSDisk{
+			DiskSettings: machinev1beta1.DiskSettings{},
+			DiskSizeGB:   128,
+			ManagedDisk: machinev1beta1.OSDiskManagedDiskParameters{
+				StorageAccountType: "Premium_LRS",
+			},
+			OSType: "Linux",
+		},
+		NetworkResourceGroup:  "network-resource-group-12345678",
+		InternalLoadBalancer:  m.internalLoadBalancer,
+		PublicLoadBalancer:    "public-load-balancer-12345678",
+		PublicIP:              false,
+		ResourceGroup:         "resource-group-12345678",
+		Zone:                  m.zone,
+		AcceleratedNetworking: true,
+		Subnet:                m.subnet,
+	}
+}
+
+// BuildRawExtension builds a new Azure machine config based on the configuration provided.
+func (m AzureProviderSpecBuilder) BuildRawExtension() *runtime.RawExtension {
+	providerConfig := m.Build()
+
+	raw, err := json.Marshal(providerConfig)
+	if err != nil {
+		// As we are building the input to json.Marshal, this should never happen.
+		panic(err)
+	}
+
+	return &runtime.RawExtension{
+		Raw: raw,
+	}
+}
+
+// WithInternalLoadBalancer sets the internalLoadBalancer for the Azure machine config builder.
+func (m AzureProviderSpecBuilder) WithInternalLoadBalancer(lb string) AzureProviderSpecBuilder {
+	m.internalLoadBalancer = lb
+	return m
+}
+
+// WithVMSize sets the VMSize (Instance type) for the Azure machine config builder.
+func (m AzureProviderSpecBuilder) WithVMSize(vmSize string) AzureProviderSpecBuilder {
+	m.vmSize = vmSize
+	return m
+}
+
+// WithZone sets the availabilityZone for the Azure machine config builder.
+func (m AzureProviderSpecBuilder) WithZone(az string) AzureProviderSpecBuilder {
+	m.zone = az
+	return m
+}
+
+// WithZone sets the availabilityZone for the Azure machine config builder.
+func (m AzureProviderSpecBuilder) WithSubnet(subnet string) AzureProviderSpecBuilder {
+	m.subnet = subnet
+	return m
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/gcp_provider_spec.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/gcp_provider_spec.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"encoding/json"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// GCPProviderSpec creates a new GCP machine config builder.
+func GCPProviderSpec() GCPProviderSpecBuilder {
+	return GCPProviderSpecBuilder{
+		disks: []*machinev1beta1.GCPDisk{
+			{
+				AutoDelete: true,
+				Boot:       true,
+				Image:      "projects/rhcos-cloud/global/images/rhcos-411-85-202205101201-0-gcp-x86-64",
+				SizeGB:     128,
+				Type:       "pd-ssd",
+			},
+		},
+		machineType: "n1-standard-4",
+		projectID:   "openshift-cpms-unit-tests",
+		targetPools: []string{"target-pool-1", "target-pool-2"},
+		zone:        "us-central1-a",
+	}
+}
+
+// GCPProviderSpecBuilder is used to build a GCP machine config object.
+type GCPProviderSpecBuilder struct {
+	disks       []*machinev1beta1.GCPDisk
+	machineType string
+	projectID   string
+	targetPools []string
+	zone        string
+}
+
+// Build builds a new GCP machine config based on the configuration provided.
+func (m GCPProviderSpecBuilder) Build() *machinev1beta1.GCPMachineProviderSpec {
+	return &machinev1beta1.GCPMachineProviderSpec{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machine.openshift.io/v1beta1",
+			Kind:       "GCPMachineProviderSpec",
+		},
+		MachineType: m.machineType,
+		UserDataSecret: &corev1.LocalObjectReference{
+			Name: "gcp-user-data-12345678",
+		},
+		TargetPools:        m.targetPools,
+		DeletionProtection: false,
+		NetworkInterfaces: []*machinev1beta1.GCPNetworkInterface{{
+			Network:    "gcp-network-12345678",
+			Subnetwork: "gcp-subnetwork-12345678",
+		}},
+		CredentialsSecret: &corev1.LocalObjectReference{
+			Name: "gcp-cloud-credentials",
+		},
+		Zone:         m.zone,
+		CanIPForward: false,
+		ProjectID:    m.projectID,
+		Region:       "us-central1",
+		Disks:        m.disks,
+		Tags: []string{
+			"gcp-tag-12345678",
+		},
+		ServiceAccounts: []machinev1beta1.GCPServiceAccount{
+			{
+				Email: "service-account-12345678",
+				Scopes: []string{
+					"https://www.googleapis.com/auth/cloud-platform",
+				},
+			},
+		},
+	}
+}
+
+// BuildRawExtension builds a new GCP machine config based on the configuration provided.
+func (m GCPProviderSpecBuilder) BuildRawExtension() *runtime.RawExtension {
+	providerConfig := m.Build()
+
+	raw, err := json.Marshal(providerConfig)
+	if err != nil {
+		// As we are building the input to json.Marshal, this should never happen.
+		panic(err)
+	}
+
+	return &runtime.RawExtension{
+		Raw: raw,
+	}
+}
+
+// WithDisks sets the disks for a machine config builder.
+func (m GCPProviderSpecBuilder) WithDisks(disks []*machinev1beta1.GCPDisk) GCPProviderSpecBuilder {
+	m.disks = disks
+	return m
+}
+
+// WithMachineType sets the machine type for the GCP machine config builder.
+func (m GCPProviderSpecBuilder) WithMachineType(machineType string) GCPProviderSpecBuilder {
+	m.machineType = machineType
+	return m
+}
+
+// WithProjectID sets the project ID for the gcp machine config builder.
+func (m GCPProviderSpecBuilder) WithProjectID(project string) GCPProviderSpecBuilder {
+	m.projectID = project
+	return m
+}
+
+// WithTargetPools sets the target pools for the GCP machine config builder.
+func (m GCPProviderSpecBuilder) WithTargetPools(targetPools []string) GCPProviderSpecBuilder {
+	m.targetPools = targetPools
+	return m
+}
+
+// WithZone sets the zone for the GCP machine config builder.
+func (m GCPProviderSpecBuilder) WithZone(zone string) GCPProviderSpecBuilder {
+	m.zone = zone
+	return m
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/machine.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/machine.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Machine creates a new machine builder.
+func Machine() MachineBuilder {
+	return MachineBuilder{}
+}
+
+// MachineBuilder is used to build out a machine object.
+type MachineBuilder struct {
+	generateName        string
+	name                string
+	namespace           string
+	labels              map[string]string
+	creationTimestamp   metav1.Time
+	deletionTimestamp   *metav1.Time
+	providerSpecBuilder resourcebuilder.RawExtensionBuilder
+
+	// status fields
+	errorMessage *string
+	nodeRef      *corev1.ObjectReference
+	phase        *string
+}
+
+// Build builds a new machine based on the configuration provided.
+func (m MachineBuilder) Build() *machinev1beta1.Machine {
+	machine := &machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName:      m.generateName,
+			CreationTimestamp: m.creationTimestamp,
+			DeletionTimestamp: m.deletionTimestamp,
+			Name:              m.name,
+			Namespace:         m.namespace,
+			Labels:            m.labels,
+		},
+		Status: machinev1beta1.MachineStatus{
+			ErrorMessage: m.errorMessage,
+			Phase:        m.phase,
+			NodeRef:      m.nodeRef,
+		},
+	}
+
+	if m.providerSpecBuilder != nil {
+		machine.Spec.ProviderSpec.Value = m.providerSpecBuilder.BuildRawExtension()
+	}
+
+	m.WithLabel(machinev1beta1.MachineClusterIDLabel, resourcebuilder.TestClusterIDValue)
+
+	return machine
+}
+
+// AsWorker sets the worker role and type on the machine labels for the machine builder.
+func (m MachineBuilder) AsWorker() MachineBuilder {
+	return m.
+		WithLabel(resourcebuilder.MachineRoleLabelName, "worker").
+		WithLabel(resourcebuilder.MachineTypeLabelName, "worker")
+}
+
+// AsMaster sets the master role and type on the machine labels for the machine builder.
+func (m MachineBuilder) AsMaster() MachineBuilder {
+	return m.
+		WithLabel(resourcebuilder.MachineRoleLabelName, "master").
+		WithLabel(resourcebuilder.MachineTypeLabelName, "master")
+}
+
+// WithCreationTimestamp sets the creationTimestamp for the machine builder.
+func (m MachineBuilder) WithCreationTimestamp(time metav1.Time) MachineBuilder {
+	m.creationTimestamp = time
+	return m
+}
+
+// WithDeletionTimestamp sets the deletionTimestamp for the machine builder.
+// Note: This can only be used in unit testing as the API server will drop this
+// field if a create/update request tries to set it.
+func (m MachineBuilder) WithDeletionTimestamp(time *metav1.Time) MachineBuilder {
+	m.deletionTimestamp = time
+	return m
+}
+
+// WithGenerateName sets the generateName for the machine builder.
+func (m MachineBuilder) WithGenerateName(generateName string) MachineBuilder {
+	m.generateName = generateName
+	return m
+}
+
+// WithLabel sets the labels for the machine builder.
+func (m MachineBuilder) WithLabel(key, value string) MachineBuilder {
+	if m.labels == nil {
+		m.labels = make(map[string]string)
+	}
+
+	m.labels[key] = value
+
+	return m
+}
+
+// WithLabels sets the labels for the machine builder.
+func (m MachineBuilder) WithLabels(labels map[string]string) MachineBuilder {
+	m.labels = labels
+	return m
+}
+
+// WithName sets the name for the machine builder.
+func (m MachineBuilder) WithName(name string) MachineBuilder {
+	m.name = name
+	return m
+}
+
+// WithNamespace sets the namespace for the machine builder.
+func (m MachineBuilder) WithNamespace(namespace string) MachineBuilder {
+	m.namespace = namespace
+	return m
+}
+
+// WithProviderSpecBuilder sets the providerSpec builder for the machine builder.
+func (m MachineBuilder) WithProviderSpecBuilder(builder resourcebuilder.RawExtensionBuilder) MachineBuilder {
+	m.providerSpecBuilder = builder
+	return m
+}
+
+// Status Fields
+
+// WithErrorMessage sets the error message status field for the machine builder.
+func (m MachineBuilder) WithErrorMessage(errorMsg string) MachineBuilder {
+	m.errorMessage = &errorMsg
+	return m
+}
+
+// WithPhase sets the phase status field for the machine builder.
+func (m MachineBuilder) WithPhase(phase string) MachineBuilder {
+	m.phase = &phase
+	return m
+}
+
+// WithNodeRef sets the node ref status field for the machine builder.
+func (m MachineBuilder) WithNodeRef(nodeRef corev1.ObjectReference) MachineBuilder {
+	m.nodeRef = &nodeRef
+	return m
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/machineset.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/machineset.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	machineSetMachineRoleLabelName = "machine.openshift.io/cluster-api-machine-role"
+	machineSetMachineTypeLabelName = "machine.openshift.io/cluster-api-machine-type"
+)
+
+// MachineSet creates a new machineSet builder.
+func MachineSet() MachineSetBuilder {
+	return MachineSetBuilder{}
+}
+
+// MachineSetBuilder is used to build out a machineSet object.
+type MachineSetBuilder struct {
+	generateName        string
+	name                string
+	namespace           string
+	replicas            int32
+	labels              map[string]string
+	creationTimestamp   metav1.Time
+	providerSpecBuilder resourcebuilder.RawExtensionBuilder
+
+	// status fields
+	errorMessage *string
+}
+
+// Build builds a new machineSet based on the configuration provided.
+func (m MachineSetBuilder) Build() *machinev1beta1.MachineSet {
+	machineSet := &machinev1beta1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName:      m.generateName,
+			CreationTimestamp: m.creationTimestamp,
+			Name:              m.name,
+			Namespace:         m.namespace,
+			Labels:            m.labels,
+		},
+		Spec: machinev1beta1.MachineSetSpec{
+			Replicas: &m.replicas,
+			Selector: metav1.LabelSelector{
+				MatchLabels: m.labels,
+			},
+			Template: machinev1beta1.MachineTemplateSpec{
+				ObjectMeta: machinev1beta1.ObjectMeta{
+					Labels: m.labels,
+				},
+			},
+		},
+		Status: machinev1beta1.MachineSetStatus{
+			ErrorMessage: m.errorMessage,
+		},
+	}
+
+	if m.providerSpecBuilder != nil {
+		machineSet.Spec.Template.Spec.ProviderSpec.Value = m.providerSpecBuilder.BuildRawExtension()
+	}
+
+	m.WithLabel(machinev1beta1.MachineClusterIDLabel, resourcebuilder.TestClusterIDValue)
+
+	return machineSet
+}
+
+// AsWorker sets the worker role and type on the machineSet labels for the machineSet builder.
+func (m MachineSetBuilder) AsWorker() MachineSetBuilder {
+	return m.
+		WithLabel(machineSetMachineRoleLabelName, "worker").
+		WithLabel(machineSetMachineTypeLabelName, "worker")
+}
+
+// WithCreationTimestamp sets the creationTimestamp for the machineSet builder.
+func (m MachineSetBuilder) WithCreationTimestamp(time metav1.Time) MachineSetBuilder {
+	m.creationTimestamp = time
+	return m
+}
+
+// WithGenerateName sets the generateName for the machineSet builder.
+func (m MachineSetBuilder) WithGenerateName(generateName string) MachineSetBuilder {
+	m.generateName = generateName
+	return m
+}
+
+// WithLabel sets the labels for the machineSet builder.
+func (m MachineSetBuilder) WithLabel(key, value string) MachineSetBuilder {
+	if m.labels == nil {
+		m.labels = make(map[string]string)
+	}
+
+	m.labels[key] = value
+
+	return m
+}
+
+// WithLabels sets the labels for the machineSet builder.
+func (m MachineSetBuilder) WithLabels(labels map[string]string) MachineSetBuilder {
+	m.labels = labels
+	return m
+}
+
+// WithName sets the name for the machineSet builder.
+func (m MachineSetBuilder) WithName(name string) MachineSetBuilder {
+	m.name = name
+	return m
+}
+
+// WithNamespace sets the namespace for the machineSet builder.
+func (m MachineSetBuilder) WithNamespace(namespace string) MachineSetBuilder {
+	m.namespace = namespace
+	return m
+}
+
+// WithProviderSpecBuilder sets the providerSpec builder for the machineSet builder.
+func (m MachineSetBuilder) WithProviderSpecBuilder(builder resourcebuilder.RawExtensionBuilder) MachineSetBuilder {
+	m.providerSpecBuilder = builder
+	return m
+}
+
+// WithReplicas sets the replicas for the machineSet builder.
+func (m MachineSetBuilder) WithReplicas(replicas int32) MachineSetBuilder {
+	m.replicas = replicas
+	return m
+}
+
+// Status Fields
+
+// WithErrorMessage sets the error message status field for the machineSet builder.
+func (m MachineSetBuilder) WithErrorMessage(errorMsg string) MachineSetBuilder {
+	m.errorMessage = &errorMsg
+	return m
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/openstack_provider_spec.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/openstack_provider_spec.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"encoding/json"
+
+	machinev1alpha1 "github.com/openshift/api/machine/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// OpenStackProviderSpec creates a new OpenStack machine config builder.
+func OpenStackProviderSpec() OpenStackProviderSpecBuilder {
+	return OpenStackProviderSpecBuilder{
+		flavor:                 "m1.large",
+		availabilityZone:       "",
+		rootVolume:             nil,
+		serverGroupName:        "master",
+		additionalBlockDevices: nil,
+	}
+}
+
+// OpenStackProviderSpecBuilder is used to build a OpenStack machine config object.
+type OpenStackProviderSpecBuilder struct {
+	flavor                 string
+	availabilityZone       string
+	rootVolume             *machinev1alpha1.RootVolume
+	serverGroupName        string
+	additionalBlockDevices []machinev1alpha1.AdditionalBlockDevice
+}
+
+// Build builds a new OpenStack machine config based on the configuration provided.
+func (m OpenStackProviderSpecBuilder) Build() *machinev1alpha1.OpenstackProviderSpec {
+	return &machinev1alpha1.OpenstackProviderSpec{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machine.openshift.io/v1alpha1",
+			Kind:       "OpenstackProviderSpec",
+		},
+		AvailabilityZone: m.availabilityZone,
+		CloudsSecret: &v1.SecretReference{
+			Name:      "openstack-cloud-credentials",
+			Namespace: "openshift-machine-api",
+		},
+		CloudName: "openstack",
+		Flavor:    m.flavor,
+		Image:     "rhcos",
+		Networks: []machinev1alpha1.NetworkParam{
+			{
+				Subnets: []machinev1alpha1.SubnetParam{
+					{
+						Filter: machinev1alpha1.SubnetFilter{
+							ID: "810c3d97-98c2-4cf3-b0f6-8977b6e0b4b2",
+						},
+					},
+				},
+				UUID: "d06af90b-1677-4b35-a7fb-3ae023dc8f62",
+			},
+		},
+		PrimarySubnet: "810c3d97-98c2-4cf3-b0f6-8977b6e0b4b2",
+		SecurityGroups: []machinev1alpha1.SecurityGroupParam{
+			{
+				Filter: machinev1alpha1.SecurityGroupFilter{
+					Name: "test-cluster-worker",
+				},
+			},
+		},
+		ServerGroupName: m.serverGroupName,
+		ServerMetadata: map[string]string{
+			"Name":               "test-cluster-worker",
+			"openshiftClusterID": "test-cluster",
+		},
+		Tags: []string{
+			"openshiftClusterID=test-cluster",
+		},
+		Trunk: true,
+		UserDataSecret: &v1.SecretReference{
+			Name: "worker-user-data",
+		},
+		RootVolume:             m.rootVolume,
+		AdditionalBlockDevices: m.additionalBlockDevices,
+	}
+}
+
+// BuildRawExtension builds a new OpenStack machine config based on the configuration provided.
+func (m OpenStackProviderSpecBuilder) BuildRawExtension() *runtime.RawExtension {
+	providerConfig := m.Build()
+
+	raw, err := json.Marshal(providerConfig)
+	if err != nil {
+		// As we are building the input to json.Marshal, this should never happen.
+		panic(err)
+	}
+
+	return &runtime.RawExtension{
+		Raw: raw,
+	}
+}
+
+// WithZone sets the availabilityZone for the OpenStack machine config builder.
+func (m OpenStackProviderSpecBuilder) WithZone(az string) OpenStackProviderSpecBuilder {
+	m.availabilityZone = az
+	return m
+}
+
+// WithRootVolume sets the rootVolume for the OpenStack machine config builder.
+func (m OpenStackProviderSpecBuilder) WithRootVolume(rootVolume *machinev1alpha1.RootVolume) OpenStackProviderSpecBuilder {
+	m.rootVolume = rootVolume
+	return m
+}
+
+// WithFlavor sets the flavor for the OpenStack machine config builder.
+func (m OpenStackProviderSpecBuilder) WithFlavor(flavor string) OpenStackProviderSpecBuilder {
+	m.flavor = flavor
+	return m
+}
+
+// WithServerGroupName sets the server group name for the OpenStack machine config builder.
+func (m OpenStackProviderSpecBuilder) WithServerGroupName(name string) OpenStackProviderSpecBuilder {
+	m.serverGroupName = name
+	return m
+}
+
+// WithAdditionalBlockDevices sets the additional block devices for the OpenStack machine config builder.
+func (m OpenStackProviderSpecBuilder) WithAdditionalBlockDevices(additionalBlockDevices []machinev1alpha1.AdditionalBlockDevice) OpenStackProviderSpecBuilder {
+	m.additionalBlockDevices = additionalBlockDevices
+	return m
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/vsphere_provider_spec.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1/vsphere_provider_spec.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	configv1resourcebuilder "github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// VSphereProviderSpec creates a new VSphere machine config builder.
+func VSphereProviderSpec() VSphereProviderSpecBuilder {
+	return VSphereProviderSpecBuilder{
+		template: "/datacenter/vm/test-ln-xw89i22-c1627-rvtrn-rhcos",
+	}
+}
+
+// VSphereProviderSpecBuilder is used to build out a VSphere machine config object.
+type VSphereProviderSpecBuilder struct {
+	template          string
+	cpmsProviderSpec  bool
+	failureDomainName string
+	infrastructure    *configv1.Infrastructure
+	ippool            bool
+	tags              []string
+}
+
+// Build builds a new VSphere machine config based on the configuration provided.
+func (v VSphereProviderSpecBuilder) Build() *machinev1beta1.VSphereMachineProviderSpec {
+	var networkDevices []machinev1beta1.NetworkDeviceSpec
+
+	if v.infrastructure == nil {
+		v.infrastructure = configv1resourcebuilder.Infrastructure().AsVSphereWithFailureDomains("vsphere-test", nil).Build()
+	}
+
+	failureDomains := v.infrastructure.Spec.PlatformSpec.VSphere.FailureDomains
+
+	workspace := &machinev1beta1.Workspace{
+		Server:       "test-vcenter",
+		Datacenter:   "test-datacenter",
+		Datastore:    "test-datastore",
+		ResourcePool: "/test-datacenter/hosts/test-cluster/resources",
+	}
+	networkDevices = []machinev1beta1.NetworkDeviceSpec{
+		{
+			NetworkName: "test-network",
+		},
+	}
+
+	if v.ippool {
+		networkDevices[0].AddressesFromPools = []machinev1beta1.AddressesFromPool{
+			{
+				Group:    "test",
+				Resource: "IPpool",
+				Name:     "test",
+			},
+		}
+	}
+
+	template := v.template
+
+	if len(failureDomains) > 0 {
+		if v.cpmsProviderSpec {
+			workspace = &machinev1beta1.Workspace{}
+			networkDevices = nil
+			template = ""
+		} else {
+			for _, vSphereFailureDomain := range failureDomains {
+				if vSphereFailureDomain.Name == v.failureDomainName {
+					workspace = &machinev1beta1.Workspace{
+						Server:     vSphereFailureDomain.Server,
+						Datacenter: vSphereFailureDomain.Topology.Datacenter,
+						Datastore:  vSphereFailureDomain.Topology.Datastore,
+						ResourcePool: fmt.Sprintf("%s/Resources",
+							vSphereFailureDomain.Topology.ComputeCluster),
+					}
+					networkDevices[0].NetworkName = vSphereFailureDomain.Topology.Networks[0]
+					template = v.template
+
+					break
+				}
+			}
+		}
+	}
+
+	return &machinev1beta1.VSphereMachineProviderSpec{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VSphereMachineProviderSpec",
+			APIVersion: "machine.openshift.io/v1beta1",
+		},
+		NumCoresPerSocket: 4,
+		DiskGiB:           120,
+		UserDataSecret: &v1.LocalObjectReference{
+			Name: "master-user-data",
+		},
+		MemoryMiB: 16384,
+		CredentialsSecret: &v1.LocalObjectReference{
+			Name: "vsphere-cloud-credentials",
+		},
+		Network: machinev1beta1.NetworkSpec{
+			Devices: networkDevices,
+		},
+		TagIDs:    v.tags,
+		Workspace: workspace,
+		NumCPUs:   4,
+		Template:  template,
+	}
+}
+
+// BuildRawExtension builds a new VSphere machine config based on the configuration provided.
+func (v VSphereProviderSpecBuilder) BuildRawExtension() *runtime.RawExtension {
+	providerConfig := v.Build()
+
+	raw, err := json.Marshal(providerConfig)
+	if err != nil {
+		// As we are building the input to json.Marshal, this should never happen.
+		panic(err)
+	}
+
+	return &runtime.RawExtension{
+		Raw: raw,
+	}
+}
+
+// AsControlPlaneMachineSetProviderSpec the control plane machine set providerConfig is derived from the
+// infrastructure spec. when failure domains are used to populate the provider spec of descendant machines,
+// the cpms provider spec workspace, template, and network are left uninitialized to prevent ambiguity as
+// the provider spec is not used to populate the workspace, template, and network.
+func (v VSphereProviderSpecBuilder) AsControlPlaneMachineSetProviderSpec() VSphereProviderSpecBuilder {
+	v.cpmsProviderSpec = true
+	return v
+}
+
+// WithInfrastructure sets the template for the VSphere machine config builder.
+func (v VSphereProviderSpecBuilder) WithInfrastructure(infrastructure configv1.Infrastructure) VSphereProviderSpecBuilder {
+	v.infrastructure = &infrastructure
+	return v
+}
+
+// WithTemplate sets the template for the VSphere machine config builder.
+func (v VSphereProviderSpecBuilder) WithTemplate(template string) VSphereProviderSpecBuilder {
+	v.template = template
+	return v
+}
+
+// WithTags sets the tags for the VSphere machine config builder.
+func (v VSphereProviderSpecBuilder) WithTags(tags []string) VSphereProviderSpecBuilder {
+	v.tags = tags
+	return v
+}
+
+// WithZone sets the zone for the VSphere machine config builder.
+func (v VSphereProviderSpecBuilder) WithZone(zone string) VSphereProviderSpecBuilder {
+	v.failureDomainName = zone
+	return v
+}
+
+// WithIPPool sets the ippool for the VSphere machine config builder.
+func (v VSphereProviderSpecBuilder) WithIPPool() VSphereProviderSpecBuilder {
+	v.ippool = true
+	return v
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/metadata.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/metadata.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebuilder
+
+// NewMachineRoleLabels creates a new map of standard Machine labels
+// for the given role.
+func NewMachineRoleLabels(role string) map[string]string {
+	return map[string]string{
+		MachineRoleLabelName: role,
+		MachineTypeLabelName: role,
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -352,6 +352,11 @@ github.com/openshift/client-go/machine/clientset/versioned/typed/machine/v1beta1
 github.com/openshift/client-go/machine/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/machine/informers/externalversions/machine/v1beta1
 github.com/openshift/client-go/machine/listers/machine/v1beta1
+# github.com/openshift/cluster-api-actuator-pkg/testutils v0.0.0-20250425124313-1c5f483c5fb7
+## explicit; go 1.21
+github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder
+github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/config/v1
+github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder/machine/v1beta1
 # github.com/openshift/library-go v0.0.0-20240116081341-964bcb3f545c
 ## explicit; go 1.21
 github.com/openshift/library-go/pkg/certs
@@ -472,8 +477,8 @@ golang.org/x/crypto/cryptobyte/asn1
 golang.org/x/crypto/hkdf
 golang.org/x/crypto/internal/alias
 golang.org/x/crypto/internal/poly1305
-# golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
-## explicit; go 1.18
+# golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
+## explicit; go 1.20
 golang.org/x/exp/maps
 # golang.org/x/mod v0.14.0
 ## explicit; go 1.18


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/machine-api-provider-gcp/pull/108

It also relies on: https://github.com/openshift/machine-api-operator/pull/1355 and https://github.com/openshift/cluster-api-actuator-pkg/pull/404