### PR TITLE
[release-4.19] OCPBUGS-59386: Add max-concurrent-reconciles flag to machine actuator

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -82,6 +82,12 @@ func main() {
 		"Address for hosting metrics",
 	)
 
+	maxConcurrentReconciles := flag.Int(
+		"max-concurrent-reconciles",
+		1,
+		"Maximum number of concurrent reconciles per controller instance.",
+	)
+
 	// Sets up feature gates
 	defaultMutableGate := feature.DefaultMutableFeatureGate
 	gateOpts, err := features.NewFeatureGateOptions(defaultMutableGate, apifeatures.SelfManaged, apifeatures.FeatureGateMachineAPIMigration, apifeatures.FeatureGateGCPCustomAPIEndpoints)
@@ -166,7 +172,9 @@ func main() {
 		klog.Fatal(err)
 	}
 
-	if err := capimachine.AddWithActuator(mgr, machineActuator, defaultMutableGate); err != nil {
+	if err := capimachine.AddWithActuatorOpts(mgr, machineActuator, controller.Options{
+		MaxConcurrentReconciles: *maxConcurrentReconciles,
+	}, defaultMutableGate); err != nil {
 		klog.Fatal(err)
 	}
 


### PR DESCRIPTION
This enables us to configure concurrent reconciliation of the machines to speed up processing of machines during large scale up events.

This matches a performance improvement we made on Azure previously.

Cherry-pick of #124 