### PR TITLE
OCPBUGS-105414: Add the N4A machine type

### DIFF
--- a/pkg/cloud/gcp/actuators/util/gcp_machine_architecture.go
+++ b/pkg/cloud/gcp/actuators/util/gcp_machine_architecture.go
@@ -27,6 +27,7 @@ const (
 // machineTypePrefixArchitectureMap contains a map of (machineTypePrefix, architecture) tuples
 var machineTypePrefixArchitectureMap = map[string]NormalizedArch{
 	"c4a": ArchitectureArm64,
+	"n4a": ArchitectureArm64,
 	"t2a": ArchitectureArm64,
 }
 


### PR DESCRIPTION
The N4A machine type is a new arm based machine type that GCP has released. The machine type should be valid when creating machines with the machine-api.