### PR TITLE
OCPBUGS-82191: Wait for RUNNING before providerID; retry stockout

### DIFF
--- a/pkg/cloud/gcp/actuators/machine/capacity.go
+++ b/pkg/cloud/gcp/actuators/machine/capacity.go
@@ -1,0 +1,99 @@
+package machine
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	machinev1 "github.com/openshift/api/machine/v1beta1"
+	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	capacityRetryDeadline = 30 * time.Minute
+)
+
+// Pool exhausted. Retry these; they are not a bad MachineSpec.
+// https://cloud.google.com/compute/docs/reference/rest/v1/errors
+var capacityErrorCodes = sets.NewString(
+	"ZONE_RESOURCE_POOL_EXHAUSTED",
+	"ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS",
+	"REGION_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS",
+	"RESOURCE_POOL_EXHAUSTED",
+)
+
+func isCapacityOperationError(op *compute.Operation) bool {
+	if op == nil || op.Error == nil {
+		return false
+	}
+	for _, e := range op.Error.Errors {
+		if e != nil && capacityErrorCodes.Has(e.Code) {
+			return true
+		}
+	}
+	return false
+}
+
+func isCapacityAPIError(err error) bool {
+	var googleError *googleapi.Error
+	if !errors.As(err, &googleError) {
+		return false
+	}
+	for _, item := range googleError.Errors {
+		if capacityErrorCodes.Has(item.Reason) {
+			return true
+		}
+	}
+	return false
+}
+
+func messageHasCapacityErrorCode(msg string) bool {
+	for _, code := range capacityErrorCodes.List() {
+		if strings.Contains(msg, code) {
+			return true
+		}
+	}
+	return false
+}
+
+// Keep the 30m create deadline from MachineCreated=False when list missed the insert op.
+func (r *Reconciler) capacityErrorFromCondition() (error, bool) {
+	cond := findCondition(r.providerStatus.Conditions, string(machinev1.MachineCreated))
+	if cond == nil || cond.Status != metav1.ConditionFalse {
+		return nil, false
+	}
+	if !messageHasCapacityErrorCode(cond.Message) {
+		return nil, false
+	}
+	return fmt.Errorf("%s", cond.Message), true
+}
+
+func (r *Reconciler) createCapacityMayInsert(err error) error {
+	r.recordFailedInstanceCreate(err)
+	cond := findCondition(r.providerStatus.Conditions, string(machinev1.MachineCreated))
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.LastTransitionTime.IsZero() {
+		return nil
+	}
+	if time.Since(cond.LastTransitionTime.Time) >= capacityRetryDeadline {
+		return machinecontroller.InvalidMachineConfiguration("capacity exhausted after %s: %v", capacityRetryDeadline, err)
+	}
+	return nil
+}
+
+func (r *Reconciler) requeueCapacityOnCreate(err error) error {
+	if deadlineErr := r.createCapacityMayInsert(err); deadlineErr != nil {
+		return deadlineErr
+	}
+	return &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
+}
+
+// MAO ignores InvalidMachineConfiguration on Update, so this only requeues.
+func (r *Reconciler) requeueCapacityOnUpdate(err error) error {
+	r.recordFailedInstanceCreate(err)
+	return &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
+}

--- a/pkg/cloud/gcp/actuators/machine/capacity_test.go
+++ b/pkg/cloud/gcp/actuators/machine/capacity_test.go
@@ -1,0 +1,481 @@
+package machine
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1beta1"
+	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
+	computeservice "github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/services/compute"
+	tagservice "github.com/openshift/machine-api-provider-gcp/pkg/cloud/gcp/actuators/services/tags"
+	compute "google.golang.org/api/compute/v1"
+	googleapi "google.golang.org/api/googleapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type capacityTestOpts struct {
+	name       string
+	zone       string
+	projectID  string
+	providerID string
+	status     *machinev1.GCPMachineProviderStatus
+}
+
+func newCapacityTestReconciler(t *testing.T, mock *computeservice.GCPComputeServiceMock, opts capacityTestOpts) *Reconciler {
+	t.Helper()
+	if opts.name == "" {
+		opts.name = "capacity-machine"
+	}
+	if opts.zone == "" {
+		opts.zone = "us-central1-a"
+	}
+	if opts.projectID == "" {
+		opts.projectID = "test-project"
+	}
+	if opts.status == nil {
+		opts.status = &machinev1.GCPMachineProviderStatus{}
+	}
+	gate, err := NewDefaultMutableFeatureGate(nil)
+	if err != nil {
+		t.Fatalf("failed to configure feature gates: %s", err.Error())
+	}
+	infraObj := &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec:       configv1.InfrastructureSpec{PlatformSpec: configv1.PlatformSpec{Type: configv1.GCPPlatformType}},
+		Status: configv1.InfrastructureStatus{
+			InfrastructureName: "test-748kjf",
+			PlatformStatus:     &configv1.PlatformStatus{Type: configv1.GCPPlatformType, GCP: &configv1.GCPPlatformStatus{}},
+		},
+	}
+	return newReconciler(&machineScope{
+		machine: &machinev1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      opts.name,
+				Namespace: "default",
+				Labels: map[string]string{
+					machinev1.MachineClusterIDLabel: "CLUSTERID",
+				},
+			},
+		},
+		coreClient: controllerfake.NewClientBuilder().WithObjects(infraObj).WithScheme(scheme.Scheme).Build(),
+		providerSpec: &machinev1.GCPMachineProviderSpec{
+			ProjectID:   opts.projectID,
+			Region:      "us-central1",
+			Zone:        opts.zone,
+			MachineType: "n1-standard-1",
+			Disks: []*machinev1.GCPDisk{
+				{Boot: true, Image: "projects/fooproject/global/images/uefi-image"},
+			},
+		},
+		providerStatus: opts.status,
+		providerID:     opts.providerID,
+		projectID:      opts.projectID,
+		computeService: mock,
+		featureGates:   gate,
+		tagService:     tagservice.NewMockTagService(),
+	})
+}
+
+func TestCreateSyncCapacityDeadline(t *testing.T) {
+	syncCapacityErr := &googleapi.Error{
+		Code:    503,
+		Message: "The zone does not have enough resources available to fulfill the request.",
+		Errors: []googleapi.ErrorItem{
+			{Reason: "ZONE_RESOURCE_POOL_EXHAUSTED", Message: "The zone does not have enough resources available to fulfill the request."},
+		},
+	}
+
+	newCreateReconciler := func(t *testing.T, status *machinev1.GCPMachineProviderStatus) (*Reconciler, *computeservice.GCPComputeServiceMock) {
+		t.Helper()
+		_, mock := computeservice.NewComputeServiceMock()
+		mock.MockZoneOperationsList = func(project string, zone string, filter string) (*compute.OperationList, error) {
+			return &compute.OperationList{}, nil
+		}
+		mock.MockInstancesInsert = func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+			return nil, syncCapacityErr
+		}
+		mock.MockInstancesGet = func(project string, zone string, instance string) (*compute.Instance, error) {
+			return nil, &googleapi.Error{Code: 404, Message: "not found"}
+		}
+		return newCapacityTestReconciler(t, mock, capacityTestOpts{
+			name:   "sync-capacity-machine",
+			status: status,
+		}), mock
+	}
+
+	t.Run("past 30m with empty op list returns InvalidMachineConfiguration", func(t *testing.T) {
+		status := &machinev1.GCPMachineProviderStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(machinev1.MachineCreated),
+				Status:             metav1.ConditionFalse,
+				Reason:             machineCreationFailedReason,
+				Message:            syncCapacityErr.Error(),
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-31 * time.Minute)),
+			}},
+		}
+		r, mock := newCreateReconciler(t, status)
+		insertCalled := false
+		mock.MockInstancesInsert = func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+			insertCalled = true
+			return nil, syncCapacityErr
+		}
+		err := r.create()
+		if err == nil {
+			t.Fatal("expected terminal capacity deadline error")
+		}
+		if !isInvalidMachineConfigurationError(err) {
+			t.Fatalf("expected InvalidMachineConfiguration, got %T %v", err, err)
+		}
+		if !strings.Contains(err.Error(), "capacity exhausted after") {
+			t.Fatalf("expected deadline message, got %v", err)
+		}
+		if insertCalled {
+			t.Fatal("InstancesInsert must not run after capacity deadline")
+		}
+		var requeueErr *machinecontroller.RequeueAfterError
+		if errors.As(err, &requeueErr) {
+			t.Fatalf("past deadline should not keep requeueing, got %v", err)
+		}
+	})
+
+	t.Run("under 30m with empty op list still inserts then requeues", func(t *testing.T) {
+		status := &machinev1.GCPMachineProviderStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(machinev1.MachineCreated),
+				Status:             metav1.ConditionFalse,
+				Reason:             machineCreationFailedReason,
+				Message:            syncCapacityErr.Error(),
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
+			}},
+		}
+		r, mock := newCreateReconciler(t, status)
+		insertCalled := false
+		mock.MockInstancesInsert = func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+			insertCalled = true
+			return nil, syncCapacityErr
+		}
+		err := r.create()
+		if err == nil {
+			t.Fatal("expected capacity requeue under deadline")
+		}
+		if isInvalidMachineConfigurationError(err) {
+			t.Fatalf("under deadline must not return InvalidMachineConfiguration, got %v", err)
+		}
+		if !insertCalled {
+			t.Fatal("expected InstancesInsert under deadline when insert op is missing")
+		}
+		var requeueErr *machinecontroller.RequeueAfterError
+		if !errors.As(err, &requeueErr) {
+			t.Fatalf("expected RequeueAfterError, got %v", err)
+		}
+		if requeueErr.RequeueAfter != requeueAfterSeconds*time.Second {
+			t.Fatalf("expected %ds requeue, got %v", requeueAfterSeconds, requeueErr.RequeueAfter)
+		}
+	})
+}
+
+func TestWaitForRunningAndCapacityRetry(t *testing.T) {
+	asyncFailureOp := failedInsertOperation("ZONE_RESOURCE_POOL_EXHAUSTED", testZoneResourcePoolExhaustedMessage)
+	asyncFailureErr := mustOperationError(t, asyncFailureOp)
+	instanceName := "capacity-machine"
+	zone := "us-central1-a"
+	projectID := "test-project"
+	providerID := fmt.Sprintf("gce://%s/%s/%s", projectID, zone, instanceName)
+	selfLink := testInstanceSelfLink(projectID, zone, instanceName)
+
+	baseScope := func(t *testing.T, mock *computeservice.GCPComputeServiceMock, status *machinev1.GCPMachineProviderStatus) *Reconciler {
+		t.Helper()
+		return newCapacityTestReconciler(t, mock, capacityTestOpts{
+			name:       instanceName,
+			zone:       zone,
+			projectID:  projectID,
+			providerID: providerID,
+			status:     status,
+		})
+	}
+
+	assertNotProvisioned := func(t *testing.T, r *Reconciler) {
+		t.Helper()
+		if r.machine.Spec.ProviderID != nil {
+			t.Fatalf("expected providerID unset, got %q", *r.machine.Spec.ProviderID)
+		}
+		if len(r.machine.Status.Addresses) != 0 {
+			t.Fatalf("expected addresses unset, got %#v", r.machine.Status.Addresses)
+		}
+		cond := findCondition(r.providerStatus.Conditions, string(machinev1.MachineCreated))
+		if cond != nil && cond.Status == metav1.ConditionTrue {
+			t.Fatalf("expected MachineCreated not True, got %#v", cond)
+		}
+	}
+
+	t.Run("PROVISIONING does not set providerID", func(t *testing.T) {
+		_, mock := computeservice.NewComputeServiceMock()
+		mock.MockInstancesGet = func(project string, zone string, instance string) (*compute.Instance, error) {
+			return &compute.Instance{
+				Name:   instanceName,
+				Status: "PROVISIONING",
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{NetworkIP: "10.0.0.15"},
+				},
+			}, nil
+		}
+		r := baseScope(t, mock, nil)
+		err := r.update()
+		var requeueErr *machinecontroller.RequeueAfterError
+		if !errors.As(err, &requeueErr) {
+			t.Fatalf("expected requeue, got %v", err)
+		}
+		assertNotProvisioned(t, r)
+		if got := ptr.Deref(r.providerStatus.InstanceState, ""); got != "PROVISIONING" {
+			t.Fatalf("expected InstanceState PROVISIONING, got %q", got)
+		}
+	})
+
+	t.Run("STAGING does not set providerID", func(t *testing.T) {
+		_, mock := computeservice.NewComputeServiceMock()
+		mock.MockInstancesGet = func(project string, zone string, instance string) (*compute.Instance, error) {
+			return &compute.Instance{
+				Name:   instanceName,
+				Status: "STAGING",
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{NetworkIP: "10.0.0.15"},
+				},
+			}, nil
+		}
+		mock.MockZoneOperationsList = func(project string, zone string, filter string) (*compute.OperationList, error) {
+			return &compute.OperationList{
+				Items: []*compute.Operation{{Status: "DONE", TargetLink: selfLink}},
+			}, nil
+		}
+		r := baseScope(t, mock, nil)
+		err := r.update()
+		var requeueErr *machinecontroller.RequeueAfterError
+		if !errors.As(err, &requeueErr) {
+			t.Fatalf("expected requeue, got %v", err)
+		}
+		assertNotProvisioned(t, r)
+	})
+
+	t.Run("capacity DONE while visible sets False and 20s requeue", func(t *testing.T) {
+		_, mock := computeservice.NewComputeServiceMock()
+		mock.MockInstancesGet = func(project string, zone string, instance string) (*compute.Instance, error) {
+			return &compute.Instance{
+				Name:   instanceName,
+				Status: "PROVISIONING",
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{NetworkIP: "10.0.0.15"},
+				},
+			}, nil
+		}
+		mock.MockZoneOperationsList = func(project string, zone string, filter string) (*compute.OperationList, error) {
+			return &compute.OperationList{
+				Items: []*compute.Operation{withTargetLink(asyncFailureOp, selfLink)},
+			}, nil
+		}
+		mock.MockInstancesInsert = func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+			t.Fatal("Update must not call InstancesInsert on capacity")
+			return nil, nil
+		}
+		r := baseScope(t, mock, nil)
+		err := r.update()
+		var requeueErr *machinecontroller.RequeueAfterError
+		if !errors.As(err, &requeueErr) {
+			t.Fatalf("expected capacity requeue, got %v", err)
+		}
+		if requeueErr.RequeueAfter != requeueAfterSeconds*time.Second {
+			t.Fatalf("expected %ds requeue, got %v", requeueAfterSeconds, requeueErr.RequeueAfter)
+		}
+		assertNotProvisioned(t, r)
+		cond := findCondition(r.providerStatus.Conditions, string(machinev1.MachineCreated))
+		if cond == nil || cond.Status != metav1.ConditionFalse || cond.Message != asyncFailureErr.Error() {
+			t.Fatalf("expected MachineCreated=False with capacity message, got %#v", cond)
+		}
+	})
+
+	t.Run("Update non-capacity insert op requeues without InvalidMachineConfiguration", func(t *testing.T) {
+		_, mock := computeservice.NewComputeServiceMock()
+		mock.MockInstancesGet = func(project string, zone string, instance string) (*compute.Instance, error) {
+			return &compute.Instance{
+				Name:   instanceName,
+				Status: "PROVISIONING",
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{NetworkIP: "10.0.0.15"},
+				},
+			}, nil
+		}
+		mock.MockZoneOperationsList = func(project string, zone string, filter string) (*compute.OperationList, error) {
+			return &compute.OperationList{
+				Items: []*compute.Operation{
+					withTargetLink(failedInsertOperation("INVALID_IMAGE", "bad image"), selfLink),
+				},
+			}, nil
+		}
+		r := baseScope(t, mock, nil)
+		err := r.update()
+		if isInvalidMachineConfigurationError(err) {
+			t.Fatalf("Update should not return InvalidMachineConfiguration, got %v", err)
+		}
+		var requeueErr *machinecontroller.RequeueAfterError
+		if !errors.As(err, &requeueErr) {
+			t.Fatalf("expected requeue, got %v", err)
+		}
+		assertNotProvisioned(t, r)
+		cond := findCondition(r.providerStatus.Conditions, string(machinev1.MachineCreated))
+		if cond == nil || cond.Status != metav1.ConditionFalse {
+			t.Fatalf("expected MachineCreated=False, got %#v", cond)
+		}
+		if !strings.Contains(cond.Message, "INVALID_IMAGE") {
+			t.Fatalf("expected INVALID_IMAGE in condition message, got %#v", cond)
+		}
+	})
+
+	t.Run("Update past 30m capacity deadline keeps requeueing while visible", func(t *testing.T) {
+		_, mock := computeservice.NewComputeServiceMock()
+		mock.MockInstancesGet = func(project string, zone string, instance string) (*compute.Instance, error) {
+			return &compute.Instance{
+				Name:   instanceName,
+				Status: "STOPPING",
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{NetworkIP: "10.0.0.15"},
+				},
+			}, nil
+		}
+		mock.MockZoneOperationsList = func(project string, zone string, filter string) (*compute.OperationList, error) {
+			return &compute.OperationList{
+				Items: []*compute.Operation{withTargetLink(asyncFailureOp, selfLink)},
+			}, nil
+		}
+		status := &machinev1.GCPMachineProviderStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(machinev1.MachineCreated),
+				Status:             metav1.ConditionFalse,
+				Reason:             machineCreationFailedReason,
+				Message:            asyncFailureErr.Error(),
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-31 * time.Minute)),
+			}},
+		}
+		r := baseScope(t, mock, status)
+		err := r.update()
+		if isInvalidMachineConfigurationError(err) {
+			t.Fatalf("Update must not return InvalidMachineConfiguration past deadline while visible, got %v", err)
+		}
+		var requeueErr *machinecontroller.RequeueAfterError
+		if !errors.As(err, &requeueErr) {
+			t.Fatalf("expected capacity requeue, got %v", err)
+		}
+		if requeueErr.RequeueAfter != requeueAfterSeconds*time.Second {
+			t.Fatalf("expected %ds requeue, got %v", requeueAfterSeconds, requeueErr.RequeueAfter)
+		}
+		assertNotProvisioned(t, r)
+	})
+
+	t.Run("RUNNING sets providerID without listing insert ops", func(t *testing.T) {
+		_, mock := computeservice.NewComputeServiceMock()
+		mock.MockZoneOperationsList = func(project string, zone string, filter string) (*compute.OperationList, error) {
+			t.Fatal("ZoneOperationsList must not run when instance is RUNNING")
+			return nil, errors.New("zone operations list failed")
+		}
+		r := baseScope(t, mock, nil)
+		if err := r.update(); err != nil {
+			t.Fatalf("expected success when RUNNING, got %v", err)
+		}
+		if r.machine.Spec.ProviderID == nil {
+			t.Fatal("expected providerID set when RUNNING")
+		}
+		cond := findCondition(r.providerStatus.Conditions, string(machinev1.MachineCreated))
+		if cond == nil || cond.Status != metav1.ConditionTrue {
+			t.Fatalf("expected MachineCreated=True, got %#v", cond)
+		}
+	})
+
+	t.Run("DONE capacity op re-inserts in the same Create", func(t *testing.T) {
+		_, mock := computeservice.NewComputeServiceMock()
+		insertCalled := false
+		mock.MockInstancesInsert = func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+			insertCalled = true
+			return &compute.Operation{Name: "retry-op", Status: "RUNNING"}, nil
+		}
+		mock.MockInstancesGet = func(project string, zone string, instance string) (*compute.Instance, error) {
+			return nil, &googleapi.Error{Code: 404, Message: "not found"}
+		}
+		mock.MockZoneOperationsList = func(project string, zone string, filter string) (*compute.OperationList, error) {
+			return &compute.OperationList{
+				Items: []*compute.Operation{withTargetLink(asyncFailureOp, selfLink)},
+			}, nil
+		}
+		status := &machinev1.GCPMachineProviderStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(machinev1.MachineCreated),
+				Status:             metav1.ConditionFalse,
+				Reason:             machineCreationFailedReason,
+				Message:            asyncFailureErr.Error(),
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-30 * time.Second)),
+			}},
+		}
+		r := baseScope(t, mock, status)
+		err := r.create()
+		if !insertCalled {
+			t.Fatal("expected InstancesInsert after DONE capacity op")
+		}
+		if isInvalidMachineConfigurationError(err) {
+			t.Fatalf("under deadline must not return InvalidMachineConfiguration, got %v", err)
+		}
+		var requeueErr *machinecontroller.RequeueAfterError
+		if !errors.As(err, &requeueErr) {
+			t.Fatalf("expected requeue after retry insert, got %v", err)
+		}
+		assertNotProvisioned(t, r)
+		cond := findCondition(r.providerStatus.Conditions, string(machinev1.MachineCreated))
+		if cond == nil || cond.Status != metav1.ConditionFalse {
+			t.Fatalf("expected MachineCreated=False, got %#v", cond)
+		}
+	})
+
+	t.Run("past 30m capacity deadline is terminal", func(t *testing.T) {
+		_, mock := computeservice.NewComputeServiceMock()
+		mock.MockZoneOperationsList = func(project string, zone string, filter string) (*compute.OperationList, error) {
+			return &compute.OperationList{
+				Items: []*compute.Operation{withTargetLink(asyncFailureOp, selfLink)},
+			}, nil
+		}
+		mock.MockInstancesGet = func(project string, zone string, instance string) (*compute.Instance, error) {
+			return nil, &googleapi.Error{Code: 404, Message: "not found"}
+		}
+		mock.MockInstancesInsert = func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+			t.Fatal("InstancesInsert must not run after capacity deadline")
+			return nil, nil
+		}
+		status := &machinev1.GCPMachineProviderStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(machinev1.MachineCreated),
+				Status:             metav1.ConditionFalse,
+				Reason:             machineCreationFailedReason,
+				Message:            asyncFailureErr.Error(),
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-31 * time.Minute)),
+			}},
+		}
+		r := baseScope(t, mock, status)
+
+		err := r.create()
+		if err == nil {
+			t.Fatal("expected terminal capacity deadline error")
+		}
+		if !isInvalidMachineConfigurationError(err) {
+			t.Fatalf("expected InvalidMachineConfiguration, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "capacity exhausted after") {
+			t.Fatalf("expected deadline message, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "ZONE_RESOURCE_POOL_EXHAUSTED") {
+			t.Fatalf("expected capacity code in deadline error, got %v", err)
+		}
+		assertNotProvisioned(t, r)
+	})
+}

--- a/pkg/cloud/gcp/actuators/machine/insertops.go
+++ b/pkg/cloud/gcp/actuators/machine/insertops.go
@@ -1,0 +1,129 @@
+package machine
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/api/compute/v1"
+)
+
+func (r *Reconciler) latestVisibleInsertOperation() (*compute.Operation, error) {
+	expectedPath := resourcePath(r.fmtInstanceSelfLink(r.projectID, r.providerSpec.Zone, r.machine.Name))
+	// targetLink:"path" returns 0 rows. Equality works.
+	filter := insertOperationTargetLinkFilter(expectedPath, r.fmtInstanceSelfLink(r.projectID, r.providerSpec.Zone, r.machine.Name))
+	opList, err := r.computeService.ZoneOperationsList(r.projectID, r.providerSpec.Zone, filter)
+	if err != nil {
+		return nil, err
+	}
+	return latestMatchingInsertOp(opList), nil
+}
+
+// Live insert ops store www.googleapis.com. The SDK BasePath can be a different host.
+func insertOperationTargetLinkFilter(expectedPath, basePathSelfLink string) string {
+	www := "https://www.googleapis.com/compute/v1" + expectedPath
+	eqs := []string{fmt.Sprintf(`targetLink="%s"`, www)}
+	if basePathSelfLink != "" && basePathSelfLink != www {
+		eqs = append(eqs, fmt.Sprintf(`targetLink="%s"`, basePathSelfLink))
+	}
+	if len(eqs) == 1 {
+		return fmt.Sprintf(`operationType="insert" AND %s`, eqs[0])
+	}
+	return fmt.Sprintf(`operationType="insert" AND (%s)`, strings.Join(eqs, " OR "))
+}
+
+// operationTime is the op's insertTime, or creationTimestamp if insertTime is empty.
+// The bool is whether that string parsed as RFC3339Nano and can be used to order ops.
+// Empty and unparsable timestamps return false so they are not treated as time zero.
+func operationTime(op *compute.Operation) (time.Time, bool) {
+	if op == nil {
+		return time.Time{}, false
+	}
+	s := op.InsertTime
+	if s == "" {
+		s = op.CreationTimestamp
+	}
+	if s == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// List order is by name. filter+orderBy is 400, so pick newest insertTime here.
+// Ops with no usable timestamp are skipped unless none of the items parsed; then
+// the last non-nil item is returned so a lone empty-time op is still visible.
+func latestMatchingInsertOp(opList *compute.OperationList) *compute.Operation {
+	if opList == nil {
+		return nil
+	}
+	var latest *compute.Operation
+	var latestTime time.Time
+	var fallback *compute.Operation
+	for _, op := range opList.Items {
+		if op == nil {
+			continue
+		}
+		fallback = op
+		t, ok := operationTime(op)
+		if !ok {
+			continue
+		}
+		if latest == nil || t.After(latestTime) {
+			latest, latestTime = op, t
+		}
+	}
+	if latest != nil {
+		return latest
+	}
+	return fallback
+}
+
+func operationError(op *compute.Operation) error {
+	if op == nil || op.Error == nil {
+		return nil
+	}
+	for _, e := range op.Error.Errors {
+		if e == nil {
+			continue
+		}
+		if e.Message != "" {
+			return fmt.Errorf("GCP operation failed: %s: %s", e.Code, e.Message)
+		}
+		if e.Code != "" {
+			return fmt.Errorf("GCP operation failed: %s", e.Code)
+		}
+	}
+	return nil
+}
+
+type insertOperationClass int
+
+const (
+	insertOperationAbsent insertOperationClass = iota
+	insertOperationInFlight
+	insertOperationSucceeded
+	insertOperationCapacityFailed
+	insertOperationTerminalFailed
+)
+
+func classifyInsertOperation(op *compute.Operation) (insertOperationClass, error) {
+	if op == nil {
+		return insertOperationAbsent, nil
+	}
+	// Error is unset until DONE. Classify failures only then so a RUNNING op
+	// is not retried as a capacity miss.
+	if op.Status != "DONE" {
+		return insertOperationInFlight, nil
+	}
+	if operationErr := operationError(op); operationErr != nil {
+		if isCapacityOperationError(op) {
+			return insertOperationCapacityFailed, operationErr
+		}
+		return insertOperationTerminalFailed, operationErr
+	}
+	return insertOperationSucceeded, nil
+}

--- a/pkg/cloud/gcp/actuators/machine/insertops_test.go
+++ b/pkg/cloud/gcp/actuators/machine/insertops_test.go
@@ -1,0 +1,248 @@
+package machine
+
+import (
+	"strings"
+	"testing"
+
+	compute "google.golang.org/api/compute/v1"
+)
+
+func TestClassifyInsertOp(t *testing.T) {
+	runningOp := &compute.Operation{Status: "RUNNING"}
+	cleanDone := &compute.Operation{Status: "DONE"}
+	runningCapacity := &compute.Operation{
+		Status: "RUNNING",
+		Error: &compute.OperationError{
+			Errors: []*compute.OperationErrorErrors{{Code: "ZONE_RESOURCE_POOL_EXHAUSTED"}},
+		},
+	}
+	capacityPool := &compute.Operation{
+		Status: "DONE",
+		Error: &compute.OperationError{
+			Errors: []*compute.OperationErrorErrors{
+				{
+					Code:    "ZONE_RESOURCE_POOL_EXHAUSTED",
+					Message: "The zone 'zones/us-central1-a' does not have enough resources available to fulfill the request.",
+				},
+			},
+		},
+	}
+	terminal := &compute.Operation{
+		Status: "DONE",
+		Error: &compute.OperationError{
+			Errors: []*compute.OperationErrorErrors{{Code: "INVALID_IMAGE", Message: "bad image"}},
+		},
+	}
+	firstOfMany := &compute.Operation{
+		Status: "DONE",
+		Error: &compute.OperationError{
+			Errors: []*compute.OperationErrorErrors{
+				{Code: "ZONE_RESOURCE_POOL_EXHAUSTED", Message: "no resources"},
+				{Code: "INVALID_IMAGE", Message: "bad image"},
+			},
+		},
+	}
+	skipNilElem := &compute.Operation{
+		Status: "DONE",
+		Error: &compute.OperationError{
+			Errors: []*compute.OperationErrorErrors{
+				nil,
+				{Code: "ZONE_RESOURCE_POOL_EXHAUSTED", Message: "no resources"},
+			},
+		},
+	}
+	onlyNilElems := &compute.Operation{
+		Status: "DONE",
+		Error: &compute.OperationError{
+			Errors: []*compute.OperationErrorErrors{nil, nil},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		op        *compute.Operation
+		wantClass insertOperationClass
+		wantErr   string
+	}{
+		{name: "nil", op: nil, wantClass: insertOperationAbsent},
+		{name: "RUNNING", op: runningOp, wantClass: insertOperationInFlight},
+		{name: "RUNNING with capacity error is still in flight", op: runningCapacity, wantClass: insertOperationInFlight},
+		{name: "DONE clean", op: cleanDone, wantClass: insertOperationSucceeded},
+		{name: "DONE capacity ZONE_RESOURCE_POOL_EXHAUSTED", op: capacityPool, wantClass: insertOperationCapacityFailed, wantErr: "GCP operation failed: ZONE_RESOURCE_POOL_EXHAUSTED: The zone 'zones/us-central1-a' does not have enough resources available to fulfill the request."},
+		{name: "DONE terminal INVALID_IMAGE", op: terminal, wantClass: insertOperationTerminalFailed, wantErr: "GCP operation failed: INVALID_IMAGE: bad image"},
+		{name: "multiple errors first wins", op: firstOfMany, wantClass: insertOperationCapacityFailed, wantErr: "GCP operation failed: ZONE_RESOURCE_POOL_EXHAUSTED: no resources"},
+		{name: "nil error elements are skipped", op: skipNilElem, wantClass: insertOperationCapacityFailed, wantErr: "GCP operation failed: ZONE_RESOURCE_POOL_EXHAUSTED: no resources"},
+		{name: "only nil error elements is succeeded DONE", op: onlyNilElems, wantClass: insertOperationSucceeded},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			class, err := classifyInsertOperation(tc.op)
+			if class != tc.wantClass {
+				t.Fatalf("classifyInsertOperation() class=%v, want %v", class, tc.wantClass)
+			}
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("classifyInsertOperation() err=%v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tc.wantErr {
+				t.Fatalf("classifyInsertOperation() err=%v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestLatestMatchingInsertOp(t *testing.T) {
+	link := testCreateInstanceSelfLink()
+	// Zone ops populate insertTime. creationTimestamp is often empty.
+	older := &compute.Operation{
+		Status:     "DONE",
+		TargetLink: link,
+		InsertTime: "2026-01-01T00:00:00.000-00:00",
+		Name:       "older",
+	}
+	newer := &compute.Operation{
+		Status:     "DONE",
+		TargetLink: link,
+		InsertTime: "2026-08-05T16:00:00.000-00:00",
+		Name:       "newer",
+	}
+
+	got := latestMatchingInsertOp(&compute.OperationList{
+		Items: []*compute.Operation{older, nil, newer},
+	})
+	if got == nil || got.Name != "newer" {
+		t.Fatalf("expected newest op, got %#v", got)
+	}
+
+	if latestMatchingInsertOp(nil) != nil {
+		t.Fatal("expected nil for nil list")
+	}
+
+	// One op only has creationTimestamp, the other only insertTime.
+	byCreationOnly := &compute.Operation{
+		Status:            "DONE",
+		TargetLink:        link,
+		CreationTimestamp: "2026-08-05T17:00:00.000-00:00",
+		Name:              "creation-only-newer",
+	}
+	byInsertOnly := &compute.Operation{
+		Status:     "DONE",
+		TargetLink: link,
+		InsertTime: "2026-08-05T16:00:00.000-00:00",
+		Name:       "insert-only-older",
+	}
+	got = latestMatchingInsertOp(&compute.OperationList{
+		Items: []*compute.Operation{byInsertOnly, byCreationOnly},
+	})
+	if got == nil || got.Name != "creation-only-newer" {
+		t.Fatalf("expected creationTimestamp-fallback op to win when newer, got %#v", got)
+	}
+
+	// 10:00-07:00 is 17:00 UTC, newer than 16:00Z. String compare would pick 16:00Z.
+	offsetNewer := &compute.Operation{
+		Status:     "DONE",
+		TargetLink: link,
+		InsertTime: "2026-08-05T10:00:00-07:00",
+		Name:       "offset-newer",
+	}
+	zuluOlder := &compute.Operation{
+		Status:     "DONE",
+		TargetLink: link,
+		InsertTime: "2026-08-05T16:00:00Z",
+		Name:       "zulu-older",
+	}
+	got = latestMatchingInsertOp(&compute.OperationList{
+		Items: []*compute.Operation{zuluOlder, offsetNewer},
+	})
+	if got == nil || got.Name != "offset-newer" {
+		t.Fatalf("expected the offset timestamp to win, got %#v", got)
+	}
+
+	emptyTime := &compute.Operation{
+		Status:     "DONE",
+		TargetLink: link,
+		Name:       "empty-time",
+	}
+	got = latestMatchingInsertOp(&compute.OperationList{
+		Items: []*compute.Operation{emptyTime},
+	})
+	if got == nil || got.Name != "empty-time" {
+		t.Fatalf("expected lone op with empty timestamps kept, got %#v", got)
+	}
+
+	unparsed := &compute.Operation{
+		Status:     "DONE",
+		TargetLink: link,
+		InsertTime: "not-a-timestamp",
+		Name:       "unparsed",
+	}
+	parsed := &compute.Operation{
+		Status:     "DONE",
+		TargetLink: link,
+		InsertTime: "2026-08-05T16:00:00Z",
+		Name:       "parsed",
+	}
+	got = latestMatchingInsertOp(&compute.OperationList{
+		Items: []*compute.Operation{unparsed, parsed},
+	})
+	if got == nil || got.Name != "parsed" {
+		t.Fatalf("expected unparsable timestamps skipped, got %#v", got)
+	}
+
+	// Empty time must not sort as time zero (oldest) ahead of a dated op.
+	got = latestMatchingInsertOp(&compute.OperationList{
+		Items: []*compute.Operation{emptyTime, parsed},
+	})
+	if got == nil || got.Name != "parsed" {
+		t.Fatalf("expected dated op over empty timestamps, got %#v", got)
+	}
+
+	got = latestMatchingInsertOp(&compute.OperationList{Items: []*compute.Operation{unparsed}})
+	if got == nil || got.Name != "unparsed" {
+		t.Fatalf("expected lone unparsable op kept, got %#v", got)
+	}
+}
+
+func TestInsertOperationTargetLinkFilter(t *testing.T) {
+	path := "/projects/openshift-gce-devel/zones/us-central1-f/instances/rmanak-dev-3-6j6w5-worker-f-227l5"
+	www := `targetLink="https://www.googleapis.com/compute/v1` + path + `"`
+
+	computeBase := "https://compute.googleapis.com/compute/v1" + path
+	filter := insertOperationTargetLinkFilter(path, computeBase)
+	if strings.Contains(filter, `targetLink:"`) {
+		t.Fatalf("filter used targetLink: HAS, got %q", filter)
+	}
+	if !strings.Contains(filter, `operationType="insert"`) {
+		t.Fatalf("expected operationType insert equality, got %q", filter)
+	}
+	if !strings.Contains(filter, www) {
+		t.Fatalf("expected www host equality in filter, got %q", filter)
+	}
+	if !strings.Contains(filter, `targetLink="`+computeBase+`"`) {
+		t.Fatalf("expected distinct BasePath in filter, got %q", filter)
+	}
+	if strings.Count(filter, `targetLink="`) != 2 {
+		t.Fatalf("expected 2 targetLink clauses (www + distinct BasePath), got %q", filter)
+	}
+
+	wwwSelfLink := "https://www.googleapis.com/compute/v1" + path
+	filter = insertOperationTargetLinkFilter(path, wwwSelfLink)
+	if strings.Count(filter, `targetLink="`) != 1 {
+		t.Fatalf("expected 1 clause when BasePath is already www, got %q", filter)
+	}
+
+	sovereign := "https://compute.example-universe.goog/compute/v1" + path
+	filter = insertOperationTargetLinkFilter(path, sovereign)
+	if !strings.Contains(filter, `targetLink="`+sovereign+`"`) {
+		t.Fatalf("expected distinct BasePath host in filter, got %q", filter)
+	}
+	if !strings.Contains(filter, www) {
+		t.Fatalf("expected www host retained alongside sovereign BasePath, got %q", filter)
+	}
+	if strings.Count(filter, `targetLink="`) != 2 {
+		t.Fatalf("expected 2 targetLink clauses (www + sovereign BasePath), got %q", filter)
+	}
+}

--- a/pkg/cloud/gcp/actuators/machine/reconciler.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler.go
@@ -419,22 +419,28 @@ func (r *Reconciler) create() error {
 		Items: metadataItems,
 	}
 
-	_, err = r.computeService.InstancesInsert(r.projectID, zone, instance)
+	shouldInsert, err := r.reconcilePriorInsertAttempt()
 	if err != nil {
-		metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
-			Name:      r.machine.Name,
-			Namespace: r.machine.Namespace,
-			Reason:    "failed to create instance via compute service",
-		})
-		if reconcileWithCloudError := r.reconcileMachineWithCloudState(&metav1.Condition{
-			Type:    string(machinev1.MachineCreated),
-			Reason:  machineCreationFailedReason,
-			Message: err.Error(),
-			Status:  metav1.ConditionFalse,
-		}); reconcileWithCloudError != nil {
-			klog.Errorf("Failed to reconcile machine with cloud state: %v", reconcileWithCloudError)
+		return err
+	}
+	if !shouldInsert {
+		// Already inserting or already reconciled.
+		return nil
+	}
+
+	insertOperation, err := r.computeService.InstancesInsert(r.projectID, zone, instance)
+	if err != nil {
+		var googleError *googleapi.Error
+		if errors.As(err, &googleError) && googleError.Code == 409 {
+			// 409 usually means the instance exists or another insert is racing.
+			klog.Infof("%s: instance create returned conflict, reconciling", r.machine.Name)
+			return r.reconcileAfterCreate()
 		}
-		if googleError, ok := err.(*googleapi.Error); ok {
+		if isCapacityAPIError(err) {
+			return r.requeueCapacityOnCreate(err)
+		}
+		r.recordFailedInstanceCreate(err)
+		if errors.As(err, &googleError) {
 			// we return InvalidMachineConfiguration for 4xx errors which by convention signal client misconfiguration
 			// https://tools.ietf.org/html/rfc2616#section-6.1.1
 			if strings.HasPrefix(strconv.Itoa(googleError.Code), "4") {
@@ -442,9 +448,61 @@ func (r *Reconciler) create() error {
 				return machinecontroller.InvalidMachineConfiguration("error launching instance: %v", googleError.Error())
 			}
 		}
-		return fmt.Errorf("failed to create instance via compute service: %v", err)
+		return fmt.Errorf("failed to create instance via compute service: %w", err)
 	}
-	return r.reconcileMachineWithCloudState(nil)
+	class, operationErr := classifyInsertOperation(insertOperation)
+	switch class {
+	case insertOperationCapacityFailed:
+		klog.Errorf("%s: insert operation completed with provider-side errors: %v", r.machine.Name, operationErr)
+		return r.requeueCapacityOnCreate(operationErr)
+	case insertOperationTerminalFailed:
+		klog.Errorf("%s: insert operation completed with provider-side errors: %v", r.machine.Name, operationErr)
+		r.recordFailedInstanceCreate(operationErr)
+		return machinecontroller.InvalidMachineConfiguration("error launching instance: %v", operationErr)
+	}
+	return r.reconcileAfterCreate()
+}
+
+// Look at the last insert op before calling InstancesInsert again.
+func (r *Reconciler) reconcilePriorInsertAttempt() (shouldInsert bool, err error) {
+	existingOp, listErr := r.latestVisibleInsertOperation()
+	if listErr != nil {
+		klog.Warningf("%s: failed to determine insert operation: %v", r.machine.Name, listErr)
+		return false, &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
+	}
+	class, operationErr := classifyInsertOperation(existingOp)
+	switch class {
+	case insertOperationAbsent:
+		if capErr, ok := r.capacityErrorFromCondition(); ok {
+			if waitErr := r.createCapacityMayInsert(capErr); waitErr != nil {
+				return false, waitErr
+			}
+		}
+		return true, nil
+	case insertOperationInFlight:
+		klog.Infof("%s: insert operation still in progress, requeuing", r.machine.Name)
+		return false, &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
+	case insertOperationCapacityFailed:
+		klog.Errorf("%s: insert operation completed with provider-side errors: %v", r.machine.Name, operationErr)
+		if waitErr := r.createCapacityMayInsert(operationErr); waitErr != nil {
+			return false, waitErr
+		}
+		klog.Infof("%s: retrying instance create after capacity error", r.machine.Name)
+		return true, nil
+	case insertOperationTerminalFailed:
+		klog.Errorf("%s: insert operation completed with provider-side errors: %v", r.machine.Name, operationErr)
+		r.recordFailedInstanceCreate(operationErr)
+		return false, machinecontroller.InvalidMachineConfiguration("error launching instance: %v", operationErr)
+	case insertOperationSucceeded:
+		klog.Infof("%s: prior insert operation succeeded, reconciling instance state", r.machine.Name)
+		recErr := r.reconcileOnUpdate()
+		if recErr != nil && isNotFoundError(recErr) {
+			klog.Infof("%s: prior insert operation succeeded but instance not found, retrying create", r.machine.Name)
+			return true, nil
+		}
+		return false, recErr
+	}
+	return true, nil
 }
 
 func (r *Reconciler) update() error {
@@ -463,72 +521,95 @@ func (r *Reconciler) update() error {
 			return fmt.Errorf("failed to register instance to instance group: %v", err)
 		}
 	}
-	return r.reconcileMachineWithCloudState(nil)
+	return r.reconcileOnUpdate()
 }
 
-// reconcileMachineWithCloudState reconcile machineSpec and status with the latest cloud state
-// if a failedCondition is passed it updates the providerStatus.Conditions and return
-// otherwise it fetches the relevant cloud instance and reconcile the rest of the fields
-func (r *Reconciler) reconcileMachineWithCloudState(failedCondition *metav1.Condition) error {
+func (r *Reconciler) reconcileAfterCreate() error {
+	return r.reconcileWithCloudState(true)
+}
+
+func (r *Reconciler) reconcileOnUpdate() error {
+	return r.reconcileWithCloudState(false)
+}
+
+// Copy instance fields onto the Machine. Wait for RUNNING before setting providerID.
+func (r *Reconciler) reconcileWithCloudState(requeueOnNotFound bool) error {
 	klog.Infof("%s: Reconciling machine object with cloud state", r.machine.Name)
-	if failedCondition != nil {
-		r.providerStatus.Conditions = reconcileConditions(r.providerStatus.Conditions, *failedCondition)
-		return nil
-	} else {
-		freshInstance, err := r.computeService.InstancesGet(r.projectID, r.providerSpec.Zone, r.machine.Name)
-		if err != nil {
-			return fmt.Errorf("failed to get instance via compute service: %v", err)
-		}
 
-		if len(freshInstance.NetworkInterfaces) < 1 {
-			return fmt.Errorf("could not find network interfaces for instance %q", freshInstance.Name)
-		}
-		networkInterface := freshInstance.NetworkInterfaces[0]
-
-		nodeAddresses := []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: networkInterface.NetworkIP}}
-		for _, config := range networkInterface.AccessConfigs {
-			nodeAddresses = append(nodeAddresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: config.NatIP})
-		}
-		// Since we don't know when the project was created, we must account for
-		// both types of internal-dns:
-		// https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names
-		// [INSTANCE_NAME].[ZONE].c.[PROJECT_ID].internal (newer)
-		nodeAddresses = append(nodeAddresses, corev1.NodeAddress{
-			Type:    corev1.NodeInternalDNS,
-			Address: fmt.Sprintf("%s.%s.c.%s.internal", r.machine.Name, r.providerSpec.Zone, r.projectID),
-		})
-		// [INSTANCE_NAME].c.[PROJECT_ID].internal
-		nodeAddresses = append(nodeAddresses, corev1.NodeAddress{
-			Type:    corev1.NodeInternalDNS,
-			Address: fmt.Sprintf("%s.c.%s.internal", r.machine.Name, r.projectID),
-		})
-		// Add the machine's name as a known NodeInternalDNS because GCP platform
-		// provides search paths to resolve those.
-		// https://cloud.google.com/compute/docs/internal-dns#resolv.conf
-		nodeAddresses = append(nodeAddresses, corev1.NodeAddress{
-			Type:    corev1.NodeInternalDNS,
-			Address: r.machine.GetName(),
-		})
-
-		r.machine.Spec.ProviderID = &r.providerID
-		r.machine.Status.Addresses = nodeAddresses
-		r.providerStatus.InstanceState = &freshInstance.Status
-		r.providerStatus.InstanceID = &freshInstance.Name
-		succeedCondition := metav1.Condition{
-			Type:    string(machinev1.MachineCreated),
-			Reason:  machineCreationSucceedReason,
-			Message: machineCreationSucceedMessage,
-			Status:  metav1.ConditionTrue,
-		}
-		r.providerStatus.Conditions = reconcileConditions(r.providerStatus.Conditions, succeedCondition)
-
-		r.setMachineCloudProviderSpecifics(freshInstance)
-
-		if freshInstance.Status != "RUNNING" {
-			klog.Infof("%s: machine status is %q, requeuing...", r.machine.Name, freshInstance.Status)
+	freshInstance, err := r.computeService.InstancesGet(r.projectID, r.providerSpec.Zone, r.machine.Name)
+	if err != nil {
+		if isNotFoundError(err) && requeueOnNotFound {
 			return &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
 		}
+		return fmt.Errorf("failed to get instance via compute service: %w", err)
 	}
+
+	r.providerStatus.InstanceState = &freshInstance.Status
+	r.providerStatus.InstanceID = &freshInstance.Name
+	r.setMachineCloudProviderSpecifics(freshInstance)
+
+	if freshInstance.Status != "RUNNING" {
+		insertOperation, opListErr := r.latestVisibleInsertOperation()
+		if opListErr != nil {
+			klog.Warningf("%s: failed to determine insert operation while reconciling: %v", r.machine.Name, opListErr)
+			return &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
+		}
+		class, operationErr := classifyInsertOperation(insertOperation)
+		switch class {
+		case insertOperationInFlight:
+			klog.Infof("%s: insert operation still in progress (instance %q), waiting for RUNNING", r.machine.Name, freshInstance.Status)
+			return &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
+		case insertOperationCapacityFailed:
+			klog.Errorf("%s: insert operation failed with capacity error while instance visible: %v", r.machine.Name, operationErr)
+			return r.requeueCapacityOnUpdate(operationErr)
+		case insertOperationTerminalFailed:
+			// MAO ignores InvalidMachineConfiguration on Update.
+			klog.Errorf("%s: insert operation completed with provider-side errors: %v", r.machine.Name, operationErr)
+			r.recordFailedInstanceCreate(operationErr)
+			return &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
+		}
+		klog.Infof("%s: machine status is %q, waiting for RUNNING", r.machine.Name, freshInstance.Status)
+		return &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
+	}
+	if len(freshInstance.NetworkInterfaces) < 1 {
+		return fmt.Errorf("could not find network interfaces for instance %q", freshInstance.Name)
+	}
+	networkInterface := freshInstance.NetworkInterfaces[0]
+
+	nodeAddresses := []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: networkInterface.NetworkIP}}
+	for _, config := range networkInterface.AccessConfigs {
+		nodeAddresses = append(nodeAddresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: config.NatIP})
+	}
+	// Since we don't know when the project was created, we must account for
+	// both types of internal-dns:
+	// https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names
+	// [INSTANCE_NAME].[ZONE].c.[PROJECT_ID].internal (newer)
+	nodeAddresses = append(nodeAddresses, corev1.NodeAddress{
+		Type:    corev1.NodeInternalDNS,
+		Address: fmt.Sprintf("%s.%s.c.%s.internal", r.machine.Name, r.providerSpec.Zone, r.projectID),
+	})
+	// [INSTANCE_NAME].c.[PROJECT_ID].internal
+	nodeAddresses = append(nodeAddresses, corev1.NodeAddress{
+		Type:    corev1.NodeInternalDNS,
+		Address: fmt.Sprintf("%s.c.%s.internal", r.machine.Name, r.projectID),
+	})
+	// Add the machine's name as a known NodeInternalDNS because GCP platform
+	// provides search paths to resolve those.
+	// https://cloud.google.com/compute/docs/internal-dns#resolv.conf
+	nodeAddresses = append(nodeAddresses, corev1.NodeAddress{
+		Type:    corev1.NodeInternalDNS,
+		Address: r.machine.GetName(),
+	})
+
+	r.machine.Spec.ProviderID = &r.providerID
+	r.machine.Status.Addresses = nodeAddresses
+	succeedCondition := metav1.Condition{
+		Type:    string(machinev1.MachineCreated),
+		Reason:  machineCreationSucceedReason,
+		Message: machineCreationSucceedMessage,
+		Status:  metav1.ConditionTrue,
+	}
+	r.providerStatus.Conditions = reconcileConditions(r.providerStatus.Conditions, succeedCondition)
 
 	return nil
 }
@@ -691,12 +772,26 @@ func (r *Reconciler) delete() error {
 	return &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second}
 }
 
-func isNotFoundError(err error) bool {
-	switch t := err.(type) {
-	case *googleapi.Error:
-		return t.Code == 404
+func (r *Reconciler) recordFailedInstanceCreate(err error) {
+	failedCondition := metav1.Condition{
+		Type:    string(machinev1.MachineCreated),
+		Reason:  machineCreationFailedReason,
+		Message: err.Error(),
+		Status:  metav1.ConditionFalse,
 	}
-	return false
+	if currentCondition := findCondition(r.providerStatus.Conditions, failedCondition.Type); currentCondition == nil || shouldUpdateCondition(*currentCondition, failedCondition) {
+		metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
+			Name:      r.machine.Name,
+			Namespace: r.machine.Namespace,
+			Reason:    "failed to create instance via compute service",
+		})
+	}
+	r.providerStatus.Conditions = reconcileConditions(r.providerStatus.Conditions, failedCondition)
+}
+
+func isNotFoundError(err error) bool {
+	var googleError *googleapi.Error
+	return errors.As(err, &googleError) && googleError.Code == 404
 }
 
 func isProjectNotFoundError(err error, projectID string) bool {

--- a/pkg/cloud/gcp/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/gcp/actuators/machine/reconciler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/googleapis/gax-go/v2/apierror"
 	configv1 "github.com/openshift/api/config/v1"
@@ -25,6 +26,57 @@ import (
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const testZoneResourcePoolExhaustedMessage = "The zone 'zones/us-central1-a' does not have enough resources available to fulfill the request."
+
+func testInstanceSelfLink(project, zone, name string) string {
+	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instances/%s", project, zone, name)
+}
+
+func testCreateInstanceSelfLink() string {
+	return testInstanceSelfLink("", "", "")
+}
+
+func failedInsertOperation(code, message string) *compute.Operation {
+	return &compute.Operation{
+		Status: "DONE",
+		Error: &compute.OperationError{
+			Errors: []*compute.OperationErrorErrors{
+				{Code: code, Message: message},
+			},
+		},
+	}
+}
+
+func withTargetLink(op *compute.Operation, targetLink string) *compute.Operation {
+	cp := *op
+	cp.TargetLink = targetLink
+	return &cp
+}
+
+func mustOperationError(t *testing.T, op *compute.Operation) error {
+	t.Helper()
+
+	err := operationError(op)
+	if err == nil {
+		t.Fatalf("expected operation error for operation %#v", op)
+	}
+
+	return err
+}
+
+func assertInsertOpListFilter(t *testing.T, filter string) {
+	t.Helper()
+	if strings.Contains(filter, `targetLink:"`) {
+		t.Fatalf("filter used targetLink: HAS, got %q", filter)
+	}
+	if !strings.Contains(filter, `operationType="insert"`) {
+		t.Fatalf("expected operationType insert equality, got %q", filter)
+	}
+	if !strings.Contains(filter, `targetLink="https://www.googleapis.com/compute/v1`) {
+		t.Fatalf("expected www host equality in filter, got %q", filter)
+	}
+}
+
 func TestCreate(t *testing.T) {
 	cases := []struct {
 		name                              string
@@ -34,6 +86,8 @@ func TestCreate(t *testing.T) {
 		secret                            *corev1.Secret
 		mockGPUCompatibleMachineTypesList func(project string, zone string, ctx context.Context) (map[string]computeservice.GpuInfo, []string)
 		mockInstancesInsert               func(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
+		mockInstancesGet                  func(project string, zone string, instance string) (*compute.Instance, error)
+		mockZoneOperationsList            func(project string, zone string, filter string) (*compute.OperationList, error)
 		mockRegionGet                     func(project string, region string) (*compute.Region, error)
 		validateInstance                  func(t *testing.T, instance *compute.Instance)
 		expectedError                     error
@@ -110,6 +164,150 @@ func TestCreate(t *testing.T) {
 			mockInstancesInsert: func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
 				return nil, &googleapi.Error{Message: "error", Code: 400}
 			},
+		},
+		{
+			name:          "Terminal on non-capacity async operation error",
+			expectedError: machinecontroller.InvalidMachineConfiguration("error launching instance: %v", "GCP operation failed: INVALID_IMAGE: bad image"),
+			expectedCondition: &metav1.Condition{
+				Type:    string(machinev1.MachineCreated),
+				Status:  metav1.ConditionFalse,
+				Reason:  machineCreationFailedReason,
+				Message: "GCP operation failed: INVALID_IMAGE: bad image",
+			},
+			mockInstancesInsert: func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+				return &compute.Operation{
+					Status: "DONE",
+					Error: &compute.OperationError{
+						Errors: []*compute.OperationErrorErrors{
+							{Code: "INVALID_IMAGE", Message: "bad image"},
+						},
+					},
+				}, nil
+			},
+		},
+		{
+			name:          "Requeue when returned operation is still RUNNING",
+			expectedError: &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second},
+			mockInstancesInsert: func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+				return &compute.Operation{Name: "running-op", Status: "RUNNING"}, nil
+			},
+			mockInstancesGet: func(project string, zone string, instance string) (*compute.Instance, error) {
+				return nil, &googleapi.Error{Code: 404}
+			},
+		},
+		{
+			name:          "Requeue when insert operation is still RUNNING",
+			expectedError: &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second},
+			mockInstancesInsert: func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+				t.Fatalf("InstancesInsert should not be called when insert operation is still running")
+				return nil, nil
+			},
+			mockZoneOperationsList: func(project string, zone string, filter string) (*compute.OperationList, error) {
+				assertInsertOpListFilter(t, filter)
+				return &compute.OperationList{
+					Items: []*compute.Operation{
+						{Status: "RUNNING", TargetLink: testCreateInstanceSelfLink()},
+					},
+				}, nil
+			},
+		},
+		{
+			name:          "Requeue when ZoneOperationsList fails",
+			expectedError: &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second},
+			mockInstancesInsert: func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+				t.Fatal("InstancesInsert must not be called when ZoneOperationsList fails")
+				return nil, nil
+			},
+			mockZoneOperationsList: func(project string, zone string, filter string) (*compute.OperationList, error) {
+				return nil, errors.New("zone operations list failed")
+			},
+		},
+		{
+			name:          "Terminal when latest visible insert operation failed non-capacity",
+			expectedError: machinecontroller.InvalidMachineConfiguration("error launching instance: %v", "GCP operation failed: INVALID_IMAGE: bad image"),
+			expectedCondition: &metav1.Condition{
+				Type:    string(machinev1.MachineCreated),
+				Status:  metav1.ConditionFalse,
+				Reason:  machineCreationFailedReason,
+				Message: "GCP operation failed: INVALID_IMAGE: bad image",
+			},
+			mockInstancesInsert: func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+				t.Fatalf("InstancesInsert should not be called for terminal non-capacity insert op failure")
+				return nil, nil
+			},
+			mockZoneOperationsList: func(project string, zone string, filter string) (*compute.OperationList, error) {
+				return &compute.OperationList{
+					Items: []*compute.Operation{
+						{
+							Status:     "DONE",
+							TargetLink: testCreateInstanceSelfLink(),
+							Error: &compute.OperationError{
+								Errors: []*compute.OperationErrorErrors{
+									{Code: "INVALID_IMAGE", Message: "bad image"},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+		},
+		{
+			name: "Reconcile on instance create conflict when instance exists",
+			mockInstancesInsert: func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+				return nil, &googleapi.Error{Code: 409, Message: "already exists"}
+			},
+			// default MockInstancesGet returns a running instance, so reconcile succeeds
+		},
+		{
+			name:          "Requeue on instance create conflict when instance not found yet",
+			expectedError: &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second},
+			mockInstancesInsert: func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+				return nil, &googleapi.Error{Code: 409, Message: "already exists"}
+			},
+			mockInstancesGet: func(project string, zone string, instance string) (*compute.Instance, error) {
+				return nil, &googleapi.Error{Code: 404, Message: "not found"}
+			},
+		},
+		{
+			name:          "Requeue on wrapped instance create conflict when instance not found yet",
+			expectedError: &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second},
+			mockInstancesInsert: func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+				return nil, fmt.Errorf("wrapped conflict: %w", &googleapi.Error{Code: 409, Message: "already exists"})
+			},
+			mockInstancesGet: func(project string, zone string, instance string) (*compute.Instance, error) {
+				return nil, &googleapi.Error{Code: 404, Message: "not found"}
+			},
+		},
+		{
+			name: "Skip re-insert when prior successful insert operation exists",
+			mockZoneOperationsList: func(project string, zone string, filter string) (*compute.OperationList, error) {
+				return &compute.OperationList{
+					Items: []*compute.Operation{
+						{Status: "DONE", TargetLink: testCreateInstanceSelfLink()},
+					},
+				}, nil
+			},
+			mockInstancesInsert: func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+				t.Fatal("InstancesInsert must not be called when a prior successful insert operation exists")
+				return nil, nil
+			},
+		},
+		{
+			name: "Re-insert when prior successful insert exists but instance is gone",
+			mockZoneOperationsList: func(project string, zone string, filter string) (*compute.OperationList, error) {
+				return &compute.OperationList{
+					Items: []*compute.Operation{
+						{Status: "DONE", TargetLink: testCreateInstanceSelfLink()},
+					},
+				}, nil
+			},
+			mockInstancesGet: func(project string, zone string, instance string) (*compute.Instance, error) {
+				return nil, &googleapi.Error{Code: 404, Message: "not found"}
+			},
+			mockInstancesInsert: func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+				return &compute.Operation{Name: "recreate-op", Status: "RUNNING"}, nil
+			},
+			expectedError: &machinecontroller.RequeueAfterError{RequeueAfter: requeueAfterSeconds * time.Second},
 		},
 		{
 			name: "Use projectID from NetworkInterface if set",
@@ -975,6 +1173,14 @@ func TestCreate(t *testing.T) {
 				mockComputeService.MockInstancesInsert = tc.mockInstancesInsert
 			}
 
+			if tc.mockInstancesGet != nil {
+				mockComputeService.MockInstancesGet = tc.mockInstancesGet
+			}
+
+			if tc.mockZoneOperationsList != nil {
+				mockComputeService.MockZoneOperationsList = tc.mockZoneOperationsList
+			}
+
 			if tc.mockGPUCompatibleMachineTypesList != nil {
 				mockComputeService.MockGPUCompatibleMachineTypesList = tc.mockGPUCompatibleMachineTypesList
 			}
@@ -1020,65 +1226,23 @@ func TestCreate(t *testing.T) {
 	}
 }
 
-func TestReconcileMachineWithCloudState(t *testing.T) {
+func TestUpdateInstanceNotFound(t *testing.T) {
 	_, mockComputeService := computeservice.NewComputeServiceMock()
-
-	zone := "us-east1-b"
-	projecID := "testProject"
-	instanceName := "testInstance"
-	machineScope := machineScope{
-		machine: &machinev1.Machine{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      instanceName,
-				Namespace: "",
-			},
-		},
-		coreClient: controllerfake.NewFakeClient(),
-		providerSpec: &machinev1.GCPMachineProviderSpec{
-			Disks: []*machinev1.GCPDisk{
-				{
-					Boot:  true,
-					Image: "projects/fooproject/global/images/uefi-image",
-				},
-			},
-			Zone: zone,
-		},
-		projectID:      projecID,
-		providerID:     fmt.Sprintf("gce://%s/%s/%s", projecID, zone, instanceName),
-		providerStatus: &machinev1.GCPMachineProviderStatus{},
-		computeService: mockComputeService,
+	mockComputeService.MockInstancesGet = func(project string, zone string, instance string) (*compute.Instance, error) {
+		return nil, &googleapi.Error{Code: 404, Message: "not found"}
 	}
 
-	expectedNodeAddresses := []corev1.NodeAddress{
-		{
-			Type:    "InternalIP",
-			Address: "10.0.0.15",
-		},
-		{
-			Type:    "ExternalIP",
-			Address: "35.243.147.143",
-		},
-	}
+	reconciler := newCapacityTestReconciler(t, mockComputeService, capacityTestOpts{})
 
-	r := newReconciler(&machineScope)
-	if err := r.reconcileMachineWithCloudState(nil); err != nil {
-		t.Errorf("reconciler was not expected to return error: %v", err)
+	err := reconciler.update()
+	if err == nil {
+		t.Fatal("expected error when instance is not found")
 	}
-	if r.machine.Status.Addresses[0] != expectedNodeAddresses[0] {
-		t.Errorf("Expected: %s, got: %s", expectedNodeAddresses[0], r.machine.Status.Addresses[0])
+	if _, ok := err.(*machinecontroller.RequeueAfterError); ok {
+		t.Fatalf("expected non-requeue error, got %v", err)
 	}
-	if r.machine.Status.Addresses[1] != expectedNodeAddresses[1] {
-		t.Errorf("Expected: %s, got: %s", expectedNodeAddresses[1], r.machine.Status.Addresses[1])
-	}
-
-	if r.providerID != *r.machine.Spec.ProviderID {
-		t.Errorf("Expected: %s, got: %s", r.providerID, *r.machine.Spec.ProviderID)
-	}
-	if *r.providerStatus.InstanceState != "RUNNING" {
-		t.Errorf("Expected: %s, got: %s", "RUNNING", *r.providerStatus.InstanceState)
-	}
-	if *r.providerStatus.InstanceID != instanceName {
-		t.Errorf("Expected: %s, got: %s", instanceName, *r.providerStatus.InstanceID)
+	if !strings.Contains(err.Error(), "failed to get instance via compute service") {
+		t.Fatalf("expected error wrapping get failure, got %q", err.Error())
 	}
 }
 

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice.go
@@ -21,7 +21,7 @@ type GCPComputeService interface {
 	InstancesInsert(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
 	InstancesGet(project string, zone string, instance string) (*compute.Instance, error)
 	ZonesGet(project string, zone string) (*compute.Zone, error)
-	ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error)
+	ZoneOperationsList(project string, zone string, filter string) (*compute.OperationList, error)
 	BasePath() string
 	TargetPoolsGet(project string, region string, name string) (*compute.TargetPool, error)
 	TargetPoolsAddInstance(project string, region string, name string, instance string) (*compute.Operation, error)
@@ -87,9 +87,9 @@ func (c *computeService) InstancesInsert(project string, zone string, instance *
 	return c.service.Instances.Insert(project, zone, instance).Do()
 }
 
-// ZoneOperationsGet is a pass through wrapper for compute.Service.ZoneOperations.Get(...)
-func (c *computeService) ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error) {
-	return c.service.ZoneOperations.Get(project, zone, operation).Do()
+// ZoneOperationsList is a pass through wrapper for compute.Service.ZoneOperations.List(...)
+func (c *computeService) ZoneOperationsList(project string, zone string, filter string) (*compute.OperationList, error) {
+	return c.service.ZoneOperations.List(project, zone).Filter(filter).Do()
 }
 
 func (c *computeService) InstancesGet(project string, zone string, instance string) (*compute.Instance, error) {

--- a/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
+++ b/pkg/cloud/gcp/actuators/services/compute/computeservice_mock.go
@@ -32,8 +32,8 @@ type GCPComputeServiceMock struct {
 	MockInstancesInsert               func(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
 	MockMachineTypesGet               func(project string, zone string, machineType string) (*compute.MachineType, error)
 	MockRegionGet                     func(project string, region string) (*compute.Region, error)
-	mockZoneOperationsGet             func(project string, zone string, operation string) (*compute.Operation, error)
-	mockInstancesGet                  func(project string, zone string, instance string) (*compute.Instance, error)
+	MockZoneOperationsList            func(project string, zone string, filter string) (*compute.OperationList, error)
+	MockInstancesGet                  func(project string, zone string, instance string) (*compute.Instance, error)
 }
 
 func (c *GCPComputeServiceMock) InstancesInsert(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
@@ -49,15 +49,15 @@ func (c *GCPComputeServiceMock) InstancesDelete(requestId string, project string
 	}, nil
 }
 
-func (c *GCPComputeServiceMock) ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error) {
-	if c.mockZoneOperationsGet == nil {
-		return nil, nil
+func (c *GCPComputeServiceMock) ZoneOperationsList(project string, zone string, filter string) (*compute.OperationList, error) {
+	if c.MockZoneOperationsList == nil {
+		return &compute.OperationList{}, nil
 	}
-	return c.mockZoneOperationsGet(project, zone, operation)
+	return c.MockZoneOperationsList(project, zone, filter)
 }
 
 func (c *GCPComputeServiceMock) InstancesGet(project string, zone string, instance string) (*compute.Instance, error) {
-	if c.mockInstancesGet == nil {
+	if c.MockInstancesGet == nil {
 		return &compute.Instance{
 			Name:         instance,
 			Zone:         zone,
@@ -76,7 +76,7 @@ func (c *GCPComputeServiceMock) InstancesGet(project string, zone string, instan
 			Status: "RUNNING",
 		}, nil
 	}
-	return c.mockInstancesGet(project, zone, instance)
+	return c.MockInstancesGet(project, zone, instance)
 }
 
 func (c *GCPComputeServiceMock) ZonesGet(project string, zone string) (*compute.Zone, error) {
@@ -125,11 +125,6 @@ func NewComputeServiceMock() (*compute.Instance, *GCPComputeServiceMock) {
 				Status: "DONE",
 			}, nil
 		},
-		mockZoneOperationsGet: func(project string, zone string, operation string) (*compute.Operation, error) {
-			return &compute.Operation{
-				Status: "DONE",
-			}, nil
-		},
 	}
 	return &receivedInstance, &computeServiceMock
 }
@@ -141,7 +136,7 @@ func MockBuilderFuncType(serviceAccountJSON string) (GCPComputeService, error) {
 
 func MockBuilderFuncTypeNotFound(serviceAccountJSON string) (GCPComputeService, error) {
 	_, computeSvc := NewComputeServiceMock()
-	computeSvc.mockInstancesGet = func(project string, zone string, instance string) (*compute.Instance, error) {
+	computeSvc.MockInstancesGet = func(project string, zone string, instance string) (*compute.Instance, error) {
 		return nil, &googleapi.Error{
 			Code: 404,
 		}


### PR DESCRIPTION
GCP can accept InstancesInsert, show a VM in PROVISIONING or STAGING, then fail the insert and delete the instance (`ZONE_RESOURCE_POOL_EXHAUSTED*`).

The controller treated that as created: it wrote providerID, addresses, and MachineCreated=True. When the VM vanished, MAO set Failed with `can't find created instance`. The GCP error never appeared on the Machine. Create never ran again.

## What this PR does

**Report the insert-op error.** List the latest matching zone insert operation (ignore ops older than Machine.CreationTimestamp minus 2 minutes). If it is DONE with a provider error, put that on MachineCreated=False. Mixed error lists are terminal unless every non-empty code is pool-exhausted.

**Do not mark the Machine created until the VM is RUNNING.** Delay providerID, addresses, and MachineCreated=True. If we write them early, MAO Faileds and Create never runs, so the error we just learned to report is unused.

**On-demand pool-exhausted: retry this Machine for 30 minutes.** The clock starts at the first `MachineCreated=False` with Reason `MachineCreationCapacityFailed`, not at an earlier 5xx False. Flat 20s requeue. After 30 minutes on Create, InvalidMachineConfiguration. A later 500 does not overwrite that Reason or reset the clock.

**Spot/preemptible stockout: do not re-insert on the same object.** InvalidMachineConfiguration immediately. MachineSet replacement is the retry.

**Quota and other non-capacity insert failures** fail immediately on Create (`QUOTA_EXCEEDED` / HTTP 403 `quotaExceeded`, bad image, mixed lists).

**TERMINATED or STOPPED before providerID:** provision never reached RUNNING. Set providerID (and addresses if NICs exist), MachineCreated=True, delete the leftover VM, requeue. MAO Faileds once Exists is false.

**TERMINATED or STOPPED after providerID:** the VM ran (or was marked created). Do not delete. Requeue and wait for RUNNING so stop/start does not Failed the Machine. STOPPING / STAGING / PROVISIONING / REPAIRING still wait. Update never returns InvalidMachineConfiguration.

```mermaid
flowchart TD
  start[Reconcile] --> exists{Instance Exists?}

  exists -->|no Create| listOp[List insert ops after Machine.CreationTimestamp minus 2m]
  listOp --> cls{Op class}
  cls -->|in flight| rq1[Requeue]
  cls -->|pool-exhausted DONE, on-demand| recFalse[MachineCreated=False Reason CapacityFailed]
  recFalse --> dead{30m since that Reason?}
  dead -->|no| insert[InstancesInsert]
  dead -->|yes| termC[InvalidMachineConfiguration]
  cls -->|pool-exhausted DONE, Spot or preemptible| termC
  cls -->|other DONE error including mixed or quota| termC
  cls -->|success DONE, Get 404| insert
  cls -->|absent / stale| insert
  insert --> afterCreate[Get instance]
  afterCreate --> waitOrSet

  exists -->|yes Update| waitOrSet[Get instance]
  waitOrSet --> st{Status}
  st -->|RUNNING| markers[Set providerID, addresses, MachineCreated=True]
  markers --> maoP[MAO: phase Provisioned]
  maoP --> node{nodeRef set?}
  node -->|yes| maoR[MAO: phase Running]
  node -->|no| rq2[Requeue until Node joins]
  st -->|TERMINATED or STOPPED, no providerID| termDel[Set markers, delete leftover VM, requeue]
  termDel --> maoF[Next pass Exists=false: MAO Failed]
  st -->|TERMINATED or STOPPED, providerID set| rqStop[Requeue, do not delete]
  st -->|STOPPING / STAGING / PROVISIONING / REPAIRING| waitOp[Classify insert op, requeue, no markers]
  waitOp -->|pool-exhausted| recU[MachineCreated=False, requeue]
  recU --> noteU[Do not insert. Do not return InvalidMachineConfiguration.]
```

## Testing

Unit tests at InstancesGet / InstancesInsert / InstancesDelete / ZoneOperationsList: no providerID before RUNNING, pool-exhausted requeue and 30m Create deadline from the capacity Reason, 5xx False does not start that clock, 500 does not reset it, quota and mixed errors terminal on Create, Spot/preemptible no re-insert, stale insert ops ignored, TERMINATED/STOPPED before providerID markers plus delete, stop/start after providerID does not delete.

Live, we verified the Failed trap on the RUNNING gate. Stockout insert ops were proven earlier (`ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS` on vanished VMs). Quota text on MachineCreated=False was seen when we still retried quota; this PR fails quota immediately on Create.

## Context & Patterns

**MAO only Faileds InvalidMachineConfiguration on Create.** Update always requeues. A GCP TERMINATED instance is powered off and can be started again. We only delete that leftover when providerID was never set. After providerID, stop/start must not Failed the Machine.

**Quota is not stockout.** Pool-exhausted is HTTP 503 / try again later. Quota is 403 / raise the project limit. Mixed lists follow the stricter class.

**The 30m epoch is a Reason, not a new condition type.** Kubernetes does not move LastTransitionTime when Status stays False. We set Reason `MachineCreationCapacityFailed` and LastTransitionTime on the first stockout so an older 5xx False cannot expire the window on the first pool-exhausted insert.

**Spot retry is a new Machine, not a second insert.** Capacity is not guaranteed. MachineSet replacement is the retry.
